### PR TITLE
Fixes for the VPCS path setting and base_script_file setting

### DIFF
--- a/gns3server/modules/vpcs/schemas.py
+++ b/gns3server/modules/vpcs/schemas.py
@@ -36,6 +36,10 @@ VPCS_CREATE_SCHEMA = {
             "type": "string",
             "minLength": 1,
         },
+        "base_script_file_base64": {
+            "description": "startup script file base64 encoded",
+            "type": "string"
+        },
     },
     "required": ["path"]
 }
@@ -73,9 +77,13 @@ VPCS_UPDATE_SCHEMA = {
             "minLength": 1,
         },
         "base_script_file": {
-            "description": "path to the VPCS startup configuration file",
+            "description": "path to the VPCS startup script file file",
             "type": "string",
             "minLength": 1,
+        },
+        "base_script_file_base64": {
+            "description": "startup script file base64 encoded",
+            "type": "string"
         },
     },
     "required": ["id"]

--- a/gns3server/modules/vpcs/vpcs_device.py
+++ b/gns3server/modules/vpcs/vpcs_device.py
@@ -48,7 +48,7 @@ class VPCSDevice(object):
     def __init__(self, path, base_script_file, working_dir, host="127.0.0.1", name=None):
 
         # find an instance identifier (1 <= id <= 512)
-        # This 255 limit is due to a restriction on the number of possible
+        # This 512 limit is due to a restriction on the number of possible
         # mac addresses given in VPCS using the -m option
         self._id = 0
         for identifier in range(1, 513):


### PR DESCRIPTION
Fixes for the VPCS path setting and base_script_file setting. The base script file setting allows a default script file to be started up with vpcs instances.
