### PR TITLE
Support IOU devices on cloud instances

### DIFF
--- a/gns3server/modules/dynamips/backends/vm.py
+++ b/gns3server/modules/dynamips/backends/vm.py
@@ -155,6 +155,7 @@ class VM(object):
 
                 provider = get_provider(self._cloud_settings)
                 provider.download_file(full_cloud_path, updated_image_path)
+                image = updated_image_path
 
         try:
             if platform not in PLATFORMS:

--- a/gns3server/modules/iou/__init__.py
+++ b/gns3server/modules/iou/__init__.py
@@ -21,12 +21,14 @@ IOU server module.
 
 import os
 import base64
+import stat
 import tempfile
 import socket
 import shutil
 
 from gns3server.modules import IModule
 from gns3server.config import Config
+from gns3dms.cloud.rackspace_ctrl import get_provider
 from .iou_device import IOUDevice
 from .iou_error import IOUError
 from .nios.nio_udp import NIO_UDP
@@ -298,6 +300,20 @@ class IOU(IModule):
         updated_iou_path = os.path.join(self.images_directory, iou_path)
         if os.path.isfile(updated_iou_path):
             iou_path = updated_iou_path
+        else:
+            if not os.path.exists(self.images_directory):
+                os.mkdir(self.images_directory)
+            if request.get("cloud_path", None):
+                # Download the image from cloud files
+                cloud_path = request.get("cloud_path")
+                full_cloud_path = "/".join((cloud_path, iou_path))
+
+                provider = get_provider(self._cloud_settings)
+                provider.download_file(full_cloud_path, updated_iou_path)
+                # Make file executable
+                st = os.stat(updated_iou_path)
+                os.chmod(updated_iou_path, st.st_mode | stat.S_IEXEC)
+                iou_path = updated_iou_path
 
         try:
             iou_instance = IOUDevice(name,

--- a/gns3server/modules/iou/schemas.py
+++ b/gns3server/modules/iou/schemas.py
@@ -40,6 +40,10 @@ IOU_CREATE_SCHEMA = {
             "description": "path to the IOU executable",
             "type": "string",
             "minLength": 1,
+        },
+        "cloud_path": {
+            "description": "Path to the image in the cloud object store",
+            "type": "string",
         }
     },
     "additionalProperties": False,


### PR DESCRIPTION
This changeset adds support for running IOU devices on a cloud instance.  It downloads the file from Cloud Files and runs it locally.

I also fixed a bug in IOS device support where the image path wasn't set correctly.
