### PR TITLE
Dynamically configure network connections of running QEMU VMs

### DIFF
--- a/gns3server/modules/qemu/qemu_vm.py
+++ b/gns3server/modules/qemu/qemu_vm.py
@@ -27,6 +27,7 @@ import subprocess
 import shlex
 import ntpath
 import telnetlib
+import time
 
 from gns3server.config import Config
 from gns3dms.cloud.rackspace_ctrl import get_provider
@@ -912,6 +913,7 @@ class QemuVM(object):
             tn = telnetlib.Telnet(self._monitor_host, self._monitor, timeout=timeout)
             try:
                 tn.write(command.encode('ascii') + b"\n")
+                time.sleep(0.1)
             except OSError as e:
                 log.warn("Could not write to QEMU monitor: {}".format(e))
                 tn.close()


### PR DESCRIPTION
To use Qemu v0.11.0 following patches to Qemu are needed:
https://github.com/shmygov/qemu-0.11.0-patches-for-gns3

To use Qemu v0.14.1 following patches to Qemu are needed:
https://github.com/shmygov/qemu-0.14.1-patches-for-gns3

These include new patches not contained in http://www.gns3.net/qemu/:

0003-qemu-0.11.0-monitor-udp.patch
0003-qemu-0.14.1-monitor-udp.patch

More testing needed with new Qemu versions.
