### PR TITLE
Use hex encoding on VirtualBox pipe names

### DIFF
--- a/gns3server/modules/virtualbox/virtualbox_vm.py
+++ b/gns3server/modules/virtualbox/virtualbox_vm.py
@@ -583,8 +583,7 @@ class VirtualBoxVM(BaseVM):
         :returns: pipe path (string)
         """
 
-        p = re.compile('\s+', re.UNICODE)
-        pipe_name = p.sub("_", self._vmname)
+        pipe_name = self._vmname.encode("hex", "strict")
         if sys.platform.startswith("win"):
             pipe_name = r"\\.\pipe\VBOX\{}".format(pipe_name)
         else:


### PR DESCRIPTION
This allows arbitrary characters in VirtualBox VM names, while also ensuring all different weird names can coexist.

Example of two VMs that previously couldn't both have a serial console - "VM 1" and "VM_1", because the former's pipe name is converted to the latter, while the latter would remain unchanged.

**P.S. NOT TESTED AT ALL.**