### PR TITLE
Do not erase the IOU config if you already have one

### DIFF
--- a/gns3server/handlers/api/iou_handler.py
+++ b/gns3server/handlers/api/iou_handler.py
@@ -58,6 +58,8 @@ class IOUHandler:
 
         for name, value in request.json.items():
             if hasattr(vm, name) and getattr(vm, name) != value:
+                if name == "initial_config_content" and (vm.initial_config_content and len(vm.initial_config_content) > 0):
+                    continue
                 setattr(vm, name, value)
         response.set_status(201)
         response.json(vm)

--- a/gns3server/modules/iou/iou_vm.py
+++ b/gns3server/modules/iou/iou_vm.py
@@ -973,7 +973,7 @@ class IOUVM(BaseVM):
             if len(initial_config) == 0 and os.path.exists(initial_config_path):
                 return
 
-            with open(initial_config_path, "w+", encoding="utf-8") as f:
+            with open(initial_config_path, 'w+', encoding='utf-8') as f:
                 if len(initial_config) == 0:
                     f.write('')
                 else:


### PR DESCRIPTION
I have try to do the same with dynamips but this part is not tested and it's deeply in the code and I fear to introduce a side effect because I can't do it in the handler.

From what I understand of the code we overwrite it at each create. It's the client which protect us against this. 