### PR TITLE
Readme + setup.py/requrements.txt sync

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,16 +20,17 @@ Branches
 master
 ******
 master is the next stable release, you can test it in your day to day activities.
-Bug fixes or small improvements pull requests goes here.
+Bug fixes or small improvements pull requests go here.
 
 unstable
 ********
-*Never* use this branch for production. Major new features pull requests goes here. 
+*Never* use this branch for production. Pull requests for major new features go here.
 
 Linux
 -----
 
 GNS3 is perhaps packaged for your distribution:
+
 * Gentoo: https://packages.gentoo.org/package/net-misc/gns3-server
 
 
@@ -76,6 +77,7 @@ You will found init sample script for various systems
 inside the init directory.
 
 Usefull options:
+
 * --daemon: start process as a daemon
 * --log logfile: store output in a logfile
 * --pid pidfile: store the pid of the running process in a file and prevent double execution
@@ -96,10 +98,39 @@ You need to copy init/gns3.conf.upstart to /etc/init/gns3.conf
 Windows
 -------
 
-Please use our all-in-one installer.
 
-If you install it via source you need to install also:
-https://sourceforge.net/projects/pywin32/
+Please use our `all-in-one installer <https://community.gns3.com/community/software/download>`_ to install the stable build.
+
+If you install via source you need to first install:
+
+- Python (3.3 or above) - https://www.python.org/downloads/windows/
+- Pywin32 - https://sourceforge.net/projects/pywin32/
+
+Then you can call
+
+.. code:: bash
+
+    python setup.py install
+
+to install the remaining dependencies.
+
+To run the tests, you also need to call
+
+.. code:: bash
+
+   pip install pytest pytest-capturelog
+
+before actually running the tests with
+
+.. code:: bash
+
+   python setup.py test
+
+or with
+
+.. code:: bash
+
+   py.test -v
 
 Mac OS X
 --------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-netifaces==0.10.4
-jsonschema==2.4.0
-python-dateutil==2.3
-aiohttp==0.15.1
-Jinja2==2.7.3
-raven==5.2.0
+jsonschema>=2.4.0
+aiohttp>=0.15.1
+Jinja2>=2.7.3
+raven>=5.2.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ from setuptools.command.test import test as TestCommand
 
 
 class PyTest(TestCommand):
-
     def finalize_options(self):
         TestCommand.finalize_options(self)
         self.test_args = []
@@ -30,17 +29,17 @@ class PyTest(TestCommand):
     def run_tests(self):
         # import here, cause outside the eggs aren't loaded
         import pytest
+
         errcode = pytest.main(self.test_args)
         sys.exit(errcode)
 
 
-dependencies = ["aiohttp>=0.15.1",
-                "jsonschema>=2.4.0",
-                "Jinja2>=2.7.3",
-                "raven>=5.2.0"]
-
-#if not sys.platform.startswith("win"):
-#    dependencies.append("netifaces==0.10.4")
+dependencies = [
+    "jsonschema>=2.4.0",
+    "aiohttp>=0.15.1",
+    "Jinja2>=2.7.3",
+    "raven>=5.2.0"
+]
 
 if sys.version_info == (3, 3):
     dependencies.append("asyncio>=3.4.2")
@@ -50,7 +49,7 @@ setup(
     version=__import__("gns3server").__version__,
     url="http://github.com/GNS3/gns3-server",
     license="GNU General Public License v3 (GPLv3)",
-    tests_require=["pytest"],
+    tests_require=["pytest", "pytest-capturelog"],
     cmdclass={"test": PyTest},
     description="GNS3 server",
     long_description=open("README.rst", "r").read(),


### PR DESCRIPTION
Similar to GNS3/gns3-gui#321 in purpose - the two files are simply not in sync.

Is python-dateutil needed btw?

I erred on the side of including it, but I honestly have no idea... a search of "dateutil" doesn't show any occurrences... Should it be removed from both places instead of being added to both?