### PR TITLE
Dedicated Qemu-img method and API call

### DIFF
--- a/gns3server/handlers/api/qemu_handler.py
+++ b/gns3server/handlers/api/qemu_handler.py
@@ -292,6 +292,21 @@ class QEMUHandler:
         binaries = yield from Qemu.binary_list()
         response.json(binaries)
 
+    @classmethod
+    @Route.get(
+        r"/qemu/img-binaries",
+        status_codes={
+            200: "Success",
+            400: "Invalid request",
+            404: "Instance doesn't exist"
+        },
+        description="Get a list of available Qemu-img binaries",
+        output=QEMU_BINARY_LIST_SCHEMA)
+    def list_img_binaries(request, response):
+
+        binaries = yield from Qemu.img_binary_list()
+        response.json(binaries)
+
     @Route.get(
         r"/qemu/vms",
         status_codes={

--- a/gns3server/modules/qemu/__init__.py
+++ b/gns3server/modules/qemu/__init__.py
@@ -39,14 +39,13 @@ class Qemu(BaseManager):
     _VM_CLASS = QemuVM
 
     @staticmethod
-    def binary_list():
+    def paths_list():
         """
-        Gets QEMU binaries list available on the host.
+        Gets a folder list of possibly available QEMU binaries on the host.
 
-        :returns: Array of dictionary {"path": Qemu binary path, "version": version of Qemu}
+        :returns: List of folders where Qemu binaries MAY reside.
         """
 
-        qemus = []
         paths = []
         try:
             paths.append(os.getcwd())
@@ -72,14 +71,25 @@ class Qemu(BaseManager):
                 paths.append(os.path.join(os.environ["PROGRAMFILES"], "qemu"))
         elif sys.platform.startswith("darwin"):
             # add specific locations on Mac OS X regardless of what's in $PATH
-            paths.extend(["/usr/local/bin", "/opt/local/bin"])
+            paths.extend(["/usr/bin", "/usr/local/bin", "/opt/local/bin"])
             if hasattr(sys, "frozen"):
                 try:
                     paths.append(os.path.abspath(os.path.join(os.getcwd(), "../../../qemu/bin/")))
                 # If the user run the server by hand from outside
                 except FileNotFoundError:
                     paths.append(["/Applications/GNS3.app/Contents/Resources/qemu/bin"])
-        for path in paths:
+        return paths
+
+    @staticmethod
+    def binary_list():
+        """
+        Gets QEMU binaries list available on the host.
+
+        :returns: Array of dictionary {"path": Qemu binary path, "version": version of Qemu}
+        """
+
+        qemus = []
+        for path in Qemu.paths_list():
             try:
                 for f in os.listdir(path):
                     if (f.startswith("qemu-system") or f.startswith("qemu-kvm") or f == "qemu" or f == "qemu.exe") and \
@@ -92,6 +102,28 @@ class Qemu(BaseManager):
                 continue
 
         return qemus
+
+    @staticmethod
+    def img_binary_list():
+        """
+        Gets QEMU-img binaries list available on the host.
+
+        :returns: Array of dictionary {"path": Qemu-img binary path, "version": version of Qemu-img}
+        """
+        qemu_imgs = []
+        for path in Qemu.paths_list():
+            try:
+                for f in os.listdir(path):
+                    if (f == "qemu-img" or f == "qemu-img.exe") and \
+                            os.access(os.path.join(path, f), os.X_OK) and \
+                            os.path.isfile(os.path.join(path, f)):
+                        qemu_path = os.path.join(path, f)
+                        version = yield from Qemu._get_qemu_img_version(qemu_path)
+                        qemu_imgs.append({"path": qemu_path, "version": version})
+            except OSError:
+                continue
+
+        return qemu_imgs
 
     @staticmethod
     @asyncio.coroutine
@@ -114,6 +146,26 @@ class Qemu(BaseManager):
                 raise QemuError("Could not determine the Qemu version for {}".format(qemu_path))
         except subprocess.SubprocessError as e:
             raise QemuError("Error while looking for the Qemu version: {}".format(e))
+
+    @staticmethod
+    @asyncio.coroutine
+    def _get_qemu_img_version(qemu_img_path):
+        """
+        Gets the Qemu-img version.
+
+        :param qemu_img_path: path to Qemu-img executable.
+        """
+
+        try:
+            output = yield from subprocess_check_output(qemu_img_path, "--version")
+            match = re.search("version\s+([0-9a-z\-\.]+)", output)
+            if match:
+                version = match.group(1)
+                return version
+            else:
+                raise QemuError("Could not determine the Qemu-img version for {}".format(qemu_img_path))
+        except subprocess.SubprocessError as e:
+            raise QemuError("Error while looking for the Qemu-img version: {}".format(e))
 
     @staticmethod
     def get_legacy_vm_workdir(legacy_vm_id, name):

--- a/tests/modules/qemu/test_qemu_manager.py
+++ b/tests/modules/qemu/test_qemu_manager.py
@@ -57,6 +57,28 @@ def test_binary_list(loop):
         assert {"path": os.path.join(os.environ["PATH"], "qemu-system-x42"), "version": version} in qemus
         assert {"path": os.path.join(os.environ["PATH"], "hello"), "version": version} not in qemus
 
+def test_img_binary_list(loop):
+
+    files_to_create = ["qemu-img", "qemu-io", "qemu-system-x86", "qemu-system-x42", "qemu-kvm", "hello"]
+
+    for file_to_create in files_to_create:
+        path = os.path.join(os.environ["PATH"], file_to_create)
+        with open(path, "w+") as f:
+            f.write("1")
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+
+    with asyncio_patch("gns3server.modules.qemu.subprocess_check_output", return_value="qemu-img version 2.2.0, Copyright (c) 2004-2008 Fabrice Bellard") as mock:
+        qemus = loop.run_until_complete(asyncio.async(Qemu.img_binary_list()))
+
+        version = "2.2.0"
+
+        assert {"path": os.path.join(os.environ["PATH"], "qemu-img"), "version": version} in qemus
+        assert {"path": os.path.join(os.environ["PATH"], "qemu-io"), "version": version} not in qemus
+        assert {"path": os.path.join(os.environ["PATH"], "qemu-system-x86"), "version": version} not in qemus
+        assert {"path": os.path.join(os.environ["PATH"], "qemu-kvm"), "version": version} not in qemus
+        assert {"path": os.path.join(os.environ["PATH"], "qemu-system-x42"), "version": version} not in qemus
+        assert {"path": os.path.join(os.environ["PATH"], "hello"), "version": version} not in qemus
+
 
 def test_get_legacy_vm_workdir():
 


### PR DESCRIPTION
This is a prerequisite for a Qemu-img wizard, which searches for the Qemu-img binary on the local server using this method, to then invoke it.

The alternative is to duplicate the path finding code into gns3-gui, but that's IMHO unnecessary and just not a good idea.