### PR TITLE
Update gns3.conf.upstart

### DIFF
--- a/init/gns3.conf.upstart
+++ b/init/gns3.conf.upstart
@@ -6,7 +6,7 @@ stop on shutdown
 
 script
     echo $$ > /var/run/gns3.pid
-    exec start-stop-daemon --start -c gns3 --exec /usr/local/bin/gns3server --log /var/log/gns3.log
+    exec start-stop-daemon --start -c gns3 --exec /usr/local/bin/gns3server -- --log /var/log/gns3.log
 end script
 
 pre-start script


### PR DESCRIPTION
Fixing start-stop-daemon syntax so that it accepts the arguments correctly on Ubuntu 14.04.

As it stands, starting the process fails with the following message because it tries to directly interpret "--log" as an option of start-stop-daemon, not an argument applied to gns3server:

start-stop-daemon: unrecognized option '--log'
Try 'start-stop-daemon --help' for more information.