### PR TITLE
EthernetSwitch: Allow to choose ethertype for QinQ outer tag.

### DIFF
--- a/docs/api/v1/dynamips_device/projectsprojectiddynamipsdevicesdeviceid.rst
+++ b/docs/api/v1/dynamips_device/projectsprojectiddynamipsdevicesdeviceid.rst
@@ -63,6 +63,7 @@ Ethernet switch port
     <tr><td>port</td>                    <td>&#10004;</td>                     <td>integer</td>                     <td>Port number</td>                     </tr>
     <tr><td>type</td>                    <td>&#10004;</td>                     <td>enum</td>                     <td>Possible values: access, dot1q, qinq</td>                     </tr>
     <tr><td>vlan</td>                    <td>&#10004;</td>                     <td>integer</td>                     <td>VLAN number</td>                     </tr>
+    <tr><td>ethertype</td>                    <td>&#10004;</td>                     <td>enum</td>                     <td>Possible values: 0x8100, 0x88A8, 0x9100, 0x9200</td>                     </tr>
     </table>
 
 Body
@@ -103,4 +104,3 @@ Response status codes
 - **400**: Invalid request
 - **404**: Instance doesn't exist
 - **204**: Instance deleted
-

--- a/gns3server/modules/dynamips/nodes/ethernet_switch.py
+++ b/gns3server/modules/dynamips/nodes/ethernet_switch.py
@@ -59,7 +59,8 @@ class EthernetSwitch(Device):
         for port_number, settings in self._mappings.items():
             ports.append({"port": port_number,
                           "type": settings[0],
-                          "vlan": settings[1]})
+                          "vlan": settings[1],
+                          "ethertype": settings[2] if len(settings) > 2 else ""})
 
         ethernet_switch_info["ports"] = ports
         return ethernet_switch_info
@@ -192,7 +193,7 @@ class EthernetSwitch(Device):
         elif settings["type"] == "dot1q":
             yield from self.set_dot1q_port(port_number, settings["vlan"])
         elif settings["type"] == "qinq":
-            yield from self.set_qinq_port(port_number, settings["vlan"])
+            yield from self.set_qinq_port(port_number, settings["vlan"], settings["ethertype"] )
 
     @asyncio.coroutine
     def set_access_port(self, port_number, vlan_id):
@@ -242,7 +243,7 @@ class EthernetSwitch(Device):
         self._mappings[port_number] = ("dot1q", native_vlan)
 
     @asyncio.coroutine
-    def set_qinq_port(self, port_number, outer_vlan):
+    def set_qinq_port(self, port_number, outer_vlan, ethertype):
         """
         Sets the specified port as a trunk (QinQ) port.
 
@@ -254,15 +255,17 @@ class EthernetSwitch(Device):
             raise DynamipsError("Port {} is not allocated".format(port_number))
 
         nio = self._nios[port_number]
-        yield from self._hypervisor.send('ethsw set_qinq_port "{name}" {nio} {outer_vlan}'.format(name=self._name,
+        yield from self._hypervisor.send('ethsw set_qinq_port "{name}" {nio} {outer_vlan} {ethertype}'.format(name=self._name,
                                                                                                   nio=nio,
-                                                                                                  outer_vlan=outer_vlan))
+                                                                                                  outer_vlan=outer_vlan,
+                                                                                                  ethertype=ethertype if ethertype != "0x8100" else ""))
 
-        log.info('Ethernet switch "{name}" [{id}]: port {port} set as a QinQ port with outer VLAN {vlan_id}'.format(name=self._name,
+        log.info('Ethernet switch "{name}" [{id}]: port {port} set as a QinQ ({ethertype}) port with outer VLAN {vlan_id}'.format(name=self._name,
                                                                                                                     id=self._id,
                                                                                                                     port=port_number,
-                                                                                                                    vlan_id=outer_vlan))
-        self._mappings[port_number] = ("qinq", outer_vlan)
+                                                                                                                    vlan_id=outer_vlan,
+                                                                                                                    ethertype=ethertype))
+        self._mappings[port_number] = ("qinq", outer_vlan, ethertype)
 
     @asyncio.coroutine
     def get_mac_addr_table(self):

--- a/gns3server/schemas/dynamips_device.py
+++ b/gns3server/schemas/dynamips_device.py
@@ -63,10 +63,15 @@ DEVICE_UPDATE_SCHEMA = {
                     "description": "Port type",
                     "enum": ["access", "dot1q", "qinq"],
                 },
+
                 "vlan": {"description": "VLAN number",
                          "type": "integer",
                          "minimum": 1
                          },
+                "ethertype": {
+                    "description": "QinQ Ethertype",
+                    "enum": ["", "0x8100", "0x88A8", "0x9100", "0x9200"],
+                },
             },
             "required": ["port", "type", "vlan"],
             "additionalProperties": False
@@ -112,6 +117,10 @@ DEVICE_OBJECT_SCHEMA = {
                          "type": "integer",
                          "minimum": 1
                          },
+                "ethertype": {
+                    "description": "QinQ Ethertype",
+                    "enum": ["", "0x8100", "0x88A8", "0x9100", "0x9200"],
+                },
             },
             "required": ["port", "type", "vlan"],
             "additionalProperties": False
@@ -321,6 +330,10 @@ DEVICE_NIO_SCHEMA = {
                          "type": "integer",
                          "minimum": 1
                          },
+                "ethertype": {
+                    "description": "QinQ Ethertype",
+                    "enum": ["", "0x8100", "0x88A8", "0x9100", "0x9200"],
+                },
             },
             "required": ["type", "vlan"],
             "additionalProperties": False


### PR DESCRIPTION
This patch makes possible to chose ethertype for Q-in-Q outer tag.
Possible values are: 0x8100 (default), 0x9100, 0x9200, 0x88A8.

Related pull requests:
GNS3/dynamips#66
GNS3/gns3-gui#618