### PR TITLE
CWD independance

### DIFF
--- a/gns3server.bat
+++ b/gns3server.bat
@@ -1,2 +1,2 @@
-SET PYTHONPATH=.
-python.exe gns3server/main.py --debug --local
+SET PYTHONPATH=%~dp0
+python.exe %~dp0/gns3server/main.py --debug --local


### PR DESCRIPTION
Currently, gns3server.bat runs the main.py relative to the CWD. However, if your CWD is not the repo root, the server fails to start.

This is very problematic, as the GUI starts and connects to whatever server is specified in its config, and if you specify the absolute path to gns3server.bat there, you start Python with the gns3-gui CWD, not the gns3-server CWD, which ultimately means the specified main.py is not found.

This PR fixes that by making the gns3server.bat run relative to itself, not relative to the CWD. The actual CWD that Python sees is still the original CWD (the gns3-gui CWD if you run gns3server.bat indirectly from the GUI), as before, but the server starts successfully regardless of CWD.