### PR TITLE
Fixed showing of Qemu hdb_disk_interface

### DIFF
--- a/gns3server/modules/qemu/qemu_vm.py
+++ b/gns3server/modules/qemu/qemu_vm.py
@@ -310,7 +310,7 @@ class QemuVM(BaseVM):
         :returns: QEMU hdb disk interface
         """
 
-        return self._hda_disk_interface
+        return self._hdb_disk_interface
 
     @hdb_disk_interface.setter
     def hdb_disk_interface(self, hdb_disk_interface):


### PR DESCRIPTION
it showed hda_disk_interface instead, which resulted in an odd visual glitch in the GUI - hdb's interface would copy over from hda when you hit the apply button, which since I accidently stumbled on this, I now realize is because the server is contacted again (since Christmas, I was trying to find it within the GUI... happy new year btw!).