### PR TITLE
Check KVM support

### DIFF
--- a/gns3server/handlers/api/qemu_handler.py
+++ b/gns3server/handlers/api/qemu_handler.py
@@ -25,7 +25,9 @@ from ...schemas.nio import NIO_SCHEMA
 from ...schemas.qemu import QEMU_CREATE_SCHEMA
 from ...schemas.qemu import QEMU_UPDATE_SCHEMA
 from ...schemas.qemu import QEMU_OBJECT_SCHEMA
+from ...schemas.qemu import QEMU_BINARY_FILTER_SCHEMA
 from ...schemas.qemu import QEMU_BINARY_LIST_SCHEMA
+from ...schemas.qemu import QEMU_CAPABILITY_LIST_SCHEMA
 from ...schemas.qemu import QEMU_IMAGE_CREATE_SCHEMA
 from ...schemas.vm import VM_LIST_IMAGES_SCHEMA
 from ...modules.qemu import Qemu
@@ -300,10 +302,11 @@ class QEMUHandler:
             404: "Instance doesn't exist"
         },
         description="Get a list of available Qemu binaries",
+        input=QEMU_BINARY_FILTER_SCHEMA,
         output=QEMU_BINARY_LIST_SCHEMA)
     def list_binaries(request, response):
 
-        binaries = yield from Qemu.binary_list()
+        binaries = yield from Qemu.binary_list(request.json["archs"] if "archs" in request.json else None)
         response.json(binaries)
 
     @classmethod
@@ -320,6 +323,21 @@ class QEMUHandler:
 
         binaries = yield from Qemu.img_binary_list()
         response.json(binaries)
+
+    @Route.get(
+        r"/qemu/capabilities",
+        status_codes={
+            200: "Success"
+        },
+        description="Get a list of Qemu capabilities on this server",
+        output=QEMU_CAPABILITY_LIST_SCHEMA
+    )
+    def get_capabilities(request, response):
+        capabilities = {}
+        kvms = Qemu.get_kvm_archs()
+        if kvms:
+            capabilities["kvm"] = kvms
+        response.json(capabilities)
 
     @classmethod
     @Route.post(

--- a/gns3server/schemas/qemu.py
+++ b/gns3server/schemas/qemu.py
@@ -601,6 +601,21 @@ QEMU_OBJECT_SCHEMA = {
                  "vm_directory"]
 }
 
+QEMU_BINARY_FILTER_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Request validation for a list of qemu capabilities",
+    "properties": {
+        "archs": {
+            "description": "Architectures to filter binaries by",
+            "type": "array",
+            "items": {
+                "enum": QEMU_PLATFORMS
+            }
+        }
+    },
+    "additionalProperties": False,
+}
+
 QEMU_BINARY_LIST_SCHEMA = {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "description": "Request validation for a list of qemu binaries",
@@ -621,6 +636,21 @@ QEMU_BINARY_LIST_SCHEMA = {
                     "type": "string",
                 },
             },
+        }
+    },
+    "additionalProperties": False,
+}
+
+QEMU_CAPABILITY_LIST_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Request validation for a list of qemu capabilities",
+    "properties": {
+        "kvm": {
+            "description": "Architectures that KVM is enabled for",
+            "type": "array",
+            "items": {
+                "enum": QEMU_PLATFORMS
+            }
         }
     },
     "additionalProperties": False,

--- a/tests/modules/qemu/test_qemu_manager.py
+++ b/tests/modules/qemu/test_qemu_manager.py
@@ -58,15 +58,29 @@ def test_binary_list(loop):
         os.chmod(path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
 
     with asyncio_patch("gns3server.modules.qemu.subprocess_check_output", return_value="QEMU emulator version 2.2.0, Copyright (c) 2003-2008 Fabrice Bellard") as mock:
-        qemus = loop.run_until_complete(asyncio.async(Qemu.binary_list()))
-
         if sys.platform.startswith("win"):
             version = ""
         else:
             version = "2.2.0"
 
+        qemus = loop.run_until_complete(asyncio.async(Qemu.binary_list()))
+
         assert {"path": os.path.join(os.environ["PATH"], "qemu-system-x86"), "version": version} in qemus
         assert {"path": os.path.join(os.environ["PATH"], "qemu-kvm"), "version": version} in qemus
+        assert {"path": os.path.join(os.environ["PATH"], "qemu-system-x42"), "version": version} in qemus
+        assert {"path": os.path.join(os.environ["PATH"], "hello"), "version": version} not in qemus
+
+        qemus = loop.run_until_complete(asyncio.async(Qemu.binary_list(["x86"])))
+
+        assert {"path": os.path.join(os.environ["PATH"], "qemu-system-x86"), "version": version} in qemus
+        assert {"path": os.path.join(os.environ["PATH"], "qemu-kvm"), "version": version} not in qemus
+        assert {"path": os.path.join(os.environ["PATH"], "qemu-system-x42"), "version": version} not in qemus
+        assert {"path": os.path.join(os.environ["PATH"], "hello"), "version": version} not in qemus
+
+        qemus = loop.run_until_complete(asyncio.async(Qemu.binary_list(["x86", "x42"])))
+
+        assert {"path": os.path.join(os.environ["PATH"], "qemu-system-x86"), "version": version} in qemus
+        assert {"path": os.path.join(os.environ["PATH"], "qemu-kvm"), "version": version} not in qemus
         assert {"path": os.path.join(os.environ["PATH"], "qemu-system-x42"), "version": version} in qemus
         assert {"path": os.path.join(os.environ["PATH"], "hello"), "version": version} not in qemus
 


### PR DESCRIPTION
Adds an API point to check if the server supports KVM. Returned as part of an object of "capabilities", that currently includes just KVM.

It's defined in this way to minimize "feature creep" - if similar functionality is later required for other system related Qemu checks, they should just be added as part of this response's output.