### PR TITLE
Improve dynamips startup_config dump

### DIFF
--- a/gns3server/modules/dynamips/__init__.py
+++ b/gns3server/modules/dynamips/__init__.py
@@ -602,6 +602,10 @@ class Dynamips(BaseManager):
         elif startup_config_content:
             startup_config_path = self._create_config(vm, default_startup_config_path, startup_config_content)
             yield from vm.set_configs(startup_config_path)
+        # An empty startup config crash dynamips
+        else:
+            startup_config_path = self._create_config(vm, default_startup_config_path, "!\n")
+            yield from vm.set_configs(startup_config_path)
 
         private_config_path = settings.get("private_config")
         private_config_content = settings.get("private_config_content")

--- a/gns3server/modules/dynamips/nodes/router.py
+++ b/gns3server/modules/dynamips/nodes/router.py
@@ -281,6 +281,7 @@ class Router(BaseVM):
             yield from self._hypervisor.send('vm stop "{name}"'.format(name=self._name))
             self.status = "stopped"
             log.info('Router "{name}" [{id}] has been stopped'.format(name=self._name, id=self._id))
+        yield from self.save_configs()
 
     @asyncio.coroutine
     def reload(self):
@@ -352,7 +353,6 @@ class Router(BaseVM):
         if self._hypervisor and not self._hypervisor.devices:
             try:
                 yield from self.stop()
-                yield from self.save_configs()
                 yield from self._hypervisor.send('vm delete "{}"'.format(self._name))
             except DynamipsError:
                 pass


### PR DESCRIPTION
Two change:
1) Dump the config when you stop the node. 
2) Disallow empty startup config. If it's empty send ! it's
avoid dynamips crash

Fix https://github.com/GNS3/gns3-gui/issues/914