### PR TITLE
VMware default VM location

### DIFF
--- a/gns3server/modules/vmware/__init__.py
+++ b/gns3server/modules/vmware/__init__.py
@@ -540,7 +540,13 @@ class VMware(BaseManager):
         """
 
         if sys.platform.startswith("win"):
-            return os.path.expandvars(r"%USERPROFILE%\Documents\Virtual Machines")
+            from win32com.shell import shell, shellcon
+            documents_folder = shell.SHGetSpecialFolderPath(None, shellcon.CSIDL_PERSONAL)
+            windows_type = sys.getwindowsversion().product_type
+            if windows_type == 2 or windows_type == 3:
+                return '{}\My Virtual Machines'.format(documents_folder)
+            else:
+                return '{}\Virtual Machines'.format(documents_folder)
         elif sys.platform.startswith("darwin"):
             return os.path.expanduser("~/Documents/Virtual Machines.localized")
         else:


### PR DESCRIPTION
Currently, the default VM location for VMware is at ```%USERPROFILE%\Documents\Virtual Machines```. But the Documents folder can be placed anywhere, independent from the user profile location. I for one have my user profile on my system drive, and most of my data folders (including the documents one) on a different drive.

And besides, according to the docs for version 12, on Windows Server, the default VM location is at a folder named "My Virtual Machines" rather than just "Virtual Machines".

This PR changes the default location to use the "Documents" folder, as found by a pywin32 call, and also checks if the windows is a server or domain controller, and uses "My Virtual Machines" if it is, and "Virtual Machines" otherwise.

I haven't tested an actual Windows Server installation with this (yet), but on Windows 10, it sure works... Despite that PyCharm is for some reason giving me an error about the "shell" and "shellcon" not being resolved.