### PR TITLE
Send command line used to start the VM to client

### DIFF
--- a/gns3server/handlers/api/iou_handler.py
+++ b/gns3server/handlers/api/iou_handler.py
@@ -148,11 +148,12 @@ class IOUHandler:
             "vm_id": "UUID for the instance"
         },
         status_codes={
-            204: "Instance started",
+            200: "Instance started",
             400: "Invalid request",
             404: "Instance doesn't exist"
         },
         input=IOU_START_SCHEMA,
+        output=IOU_OBJECT_SCHEMA,
         description="Start a IOU instance")
     def start(request, response):
 
@@ -166,7 +167,7 @@ class IOUHandler:
                 print(vm.iourc_path)
 
         yield from vm.start()
-        response.set_status(204)
+        response.json(vm)
 
     @classmethod
     @Route.post(

--- a/gns3server/handlers/api/qemu_handler.py
+++ b/gns3server/handlers/api/qemu_handler.py
@@ -146,11 +146,12 @@ class QEMUHandler:
             "vm_id": "UUID for the instance"
         },
         status_codes={
-            204: "Instance started",
+            200: "Instance started",
             400: "Invalid request",
             404: "Instance doesn't exist"
         },
-        description="Start a Qemu VM instance")
+        description="Start a Qemu VM instance",
+        output=QEMU_OBJECT_SCHEMA)
     def start(request, response):
 
         qemu_manager = Qemu.instance()
@@ -161,7 +162,7 @@ class QEMUHandler:
             if pm.check_hardware_virtualization(vm) is False:
                 raise HTTPConflict(text="Cannot start VM with KVM enabled because hardware virtualization (VT-x/AMD-V) is already used by another software like VMware or VirtualBox")
         yield from vm.start()
-        response.set_status(204)
+        response.json(vm)
 
     @classmethod
     @Route.post(

--- a/gns3server/handlers/api/vpcs_handler.py
+++ b/gns3server/handlers/api/vpcs_handler.py
@@ -130,13 +130,14 @@ class VPCSHandler:
             400: "Invalid request",
             404: "Instance doesn't exist"
         },
-        description="Start a VPCS instance")
+        description="Start a VPCS instance",
+        output=VPCS_OBJECT_SCHEMA)
     def start(request, response):
 
         vpcs_manager = VPCS.instance()
         vm = vpcs_manager.get_vm(request.match_info["vm_id"], project_id=request.match_info["project_id"])
         yield from vm.start()
-        response.set_status(204)
+        response.json(vm)
 
     @classmethod
     @Route.post(

--- a/gns3server/modules/base_vm.py
+++ b/gns3server/modules/base_vm.py
@@ -58,6 +58,7 @@ class BaseVM:
         self._hw_virtualization = False
         self._ubridge_hypervisor = None
         self._vm_status = "stopped"
+        self._command_line = ""
 
         if self._console is not None:
             if console_type == "vnc":
@@ -93,6 +94,17 @@ class BaseVM:
 
         self._vm_status = status
         self._project.emit("vm.{}".format(status), self)
+
+    @property
+    def command_line(self):
+        """Return command used to start the VM"""
+
+        return self._command_line
+
+    @command_line.setter
+    def command_line(self, command_line):
+
+        self._command_line = command_line
 
     @property
     def project(self):

--- a/gns3server/schemas/iou.py
+++ b/gns3server/schemas/iou.py
@@ -254,11 +254,16 @@ IOU_OBJECT_SCHEMA = {
         "iourc_path": {
             "description": "Path of the iourc file used by remote servers",
             "type": ["string", "null"]
+        },
+        "command_line": {
+            "description": "Last command line used by GNS3 to start QEMU",
+            "type": "string"
         }
     },
     "additionalProperties": False,
     "required": ["name", "vm_id", "console", "project_id", "path", "md5sum", "serial_adapters", "ethernet_adapters",
-                 "ram", "nvram", "l1_keepalives", "startup_config", "private_config", "use_default_iou_values"]
+                 "ram", "nvram", "l1_keepalives", "startup_config", "private_config", "use_default_iou_values",
+                 "command_line"]
 }
 
 IOU_CAPTURE_SCHEMA = {

--- a/gns3server/schemas/qemu.py
+++ b/gns3server/schemas/qemu.py
@@ -558,6 +558,10 @@ QEMU_OBJECT_SCHEMA = {
             "description": "Additional QEMU options",
             "type": "string",
         },
+        "command_line": {
+            "description": "Last command line used by GNS3 to start QEMU",
+            "type": "string"
+        }
     },
     "additionalProperties": False,
     "required": ["vm_id",
@@ -598,7 +602,8 @@ QEMU_OBJECT_SCHEMA = {
                  "cpu_throttling",
                  "process_priority",
                  "options",
-                 "vm_directory"]
+                 "vm_directory",
+                 "command_line"]
 }
 
 QEMU_BINARY_FILTER_SCHEMA = {

--- a/gns3server/schemas/vpcs.py
+++ b/gns3server/schemas/vpcs.py
@@ -121,7 +121,11 @@ VPCS_OBJECT_SCHEMA = {
             "description": "Path of the VPCS startup script relative to project directory",
             "type": ["string", "null"]
         },
+        "command_line": {
+            "description": "Last command line used by GNS3 to start QEMU",
+            "type": "string"
+        }
     },
     "additionalProperties": False,
-    "required": ["name", "vm_id", "status", "console", "project_id", "startup_script_path"]
+    "required": ["name", "vm_id", "status", "console", "project_id", "startup_script_path", "command_line"]
 }

--- a/tests/handlers/api/test_iou.py
+++ b/tests/handlers/api/test_iou.py
@@ -139,7 +139,8 @@ def test_iou_start(server, vm):
     with asyncio_patch("gns3server.modules.iou.iou_vm.IOUVM.start", return_value=True) as mock:
         response = server.post("/projects/{project_id}/iou/vms/{vm_id}/start".format(project_id=vm["project_id"], vm_id=vm["vm_id"]))
         assert mock.called
-        assert response.status == 204
+        assert response.status == 200
+        assert response.json["name"] == "PC TEST 1"
 
 
 def test_iou_start_with_iourc(server, vm, tmpdir):
@@ -148,7 +149,7 @@ def test_iou_start_with_iourc(server, vm, tmpdir):
     with asyncio_patch("gns3server.modules.iou.iou_vm.IOUVM.start", return_value=True) as mock:
         response = server.post("/projects/{project_id}/iou/vms/{vm_id}/start".format(project_id=vm["project_id"], vm_id=vm["vm_id"]), body=body, example=True)
         assert mock.called
-        assert response.status == 204
+        assert response.status == 200
 
     response = server.get("/projects/{project_id}/iou/vms/{vm_id}".format(project_id=vm["project_id"], vm_id=vm["vm_id"]))
     assert response.status == 200

--- a/tests/handlers/api/test_qemu.py
+++ b/tests/handlers/api/test_qemu.py
@@ -114,7 +114,8 @@ def test_qemu_start(server, vm):
     with asyncio_patch("gns3server.modules.qemu.qemu_vm.QemuVM.start", return_value=True) as mock:
         response = server.post("/projects/{project_id}/qemu/vms/{vm_id}/start".format(project_id=vm["project_id"], vm_id=vm["vm_id"]), example=True)
         assert mock.called
-        assert response.status == 204
+        assert response.status == 200
+        assert response.json["name"] == "PC TEST 1"
 
 
 def test_qemu_stop(server, vm):

--- a/tests/handlers/api/test_vpcs.py
+++ b/tests/handlers/api/test_vpcs.py
@@ -102,7 +102,8 @@ def test_vpcs_start(server, vm):
     with asyncio_patch("gns3server.modules.vpcs.vpcs_vm.VPCSVM.start", return_value=True) as mock:
         response = server.post("/projects/{project_id}/vpcs/vms/{vm_id}/start".format(project_id=vm["project_id"], vm_id=vm["vm_id"]), example=True)
         assert mock.called
-        assert response.status == 204
+        assert response.status == 200
+        assert response.json["name"] == "PC TEST 1"
 
 
 def test_vpcs_stop(server, vm):

--- a/tests/modules/iou/test_iou_vm.py
+++ b/tests/modules/iou/test_iou_vm.py
@@ -112,11 +112,11 @@ def test_start(loop, vm, monkeypatch):
         with asyncio_patch("gns3server.modules.iou.iou_vm.IOUVM._check_iou_licence", return_value=True):
             with asyncio_patch("gns3server.modules.iou.iou_vm.IOUVM._start_ioucon", return_value=True):
                 with asyncio_patch("gns3server.modules.iou.iou_vm.IOUVM._start_iouyap", return_value=True):
-                    with asyncio_patch("asyncio.create_subprocess_exec", return_value=mock_process):
+                    with asyncio_patch("asyncio.create_subprocess_exec", return_value=mock_process) as mock_exec:
                         mock_process.returncode = None
                         loop.run_until_complete(asyncio.async(vm.start()))
                         assert vm.is_running()
-
+                        assert vm.command_line == ' '.join(mock_exec.call_args[0])
 
 def test_start_with_iourc(loop, vm, monkeypatch, tmpdir):
 

--- a/tests/modules/qemu/test_qemu_vm.py
+++ b/tests/modules/qemu/test_qemu_vm.py
@@ -112,9 +112,10 @@ def test_is_running(vm, running_subprocess_mock):
 
 
 def test_start(loop, vm, running_subprocess_mock):
-    with asyncio_patch("asyncio.create_subprocess_exec", return_value=running_subprocess_mock):
+    with asyncio_patch("asyncio.create_subprocess_exec", return_value=running_subprocess_mock) as mock:
         loop.run_until_complete(asyncio.async(vm.start()))
         assert vm.is_running()
+        assert vm.command_line == ' '.join(mock.call_args[0])
 
 
 def test_stop(loop, vm, running_subprocess_mock):

--- a/tests/modules/vpcs/test_vpcs_vm.py
+++ b/tests/modules/vpcs/test_vpcs_vm.py
@@ -107,6 +107,7 @@ def test_start(loop, vm):
                                               '-t',
                                               '127.0.0.1')
             assert vm.is_running()
+            assert vm.command_line == ' '.join(mock_exec.call_args[0])
     (action, event) = queue.get_nowait()
     assert action == "vm.started"
     assert event == vm


### PR DESCRIPTION
Add a command_line attribute to the VM object with
the command line used to start the VM.

Now /start return the object in order to get
this new attribute. And the HTTP status code
is 200 instead of 204 because 204 disallow body.

Support:
* Qemu
* Dynamips
* IOU

Ref https://github.com/GNS3/gns3-gui/issues/513