### PR TITLE
Do not list qemu binary with -spice in the name

### DIFF
--- a/gns3server/modules/qemu/__init__.py
+++ b/gns3server/modules/qemu/__init__.py
@@ -117,6 +117,8 @@ class Qemu(BaseManager):
         for path in Qemu.paths_list():
             try:
                 for f in os.listdir(path):
+                    if f.endswith("-spice"):
+                        continue
                     if (f.startswith("qemu-system") or f.startswith("qemu-kvm") or f == "qemu" or f == "qemu.exe") and \
                             os.access(os.path.join(path, f), os.X_OK) and \
                             os.path.isfile(os.path.join(path, f)):

--- a/tests/modules/qemu/test_qemu_manager.py
+++ b/tests/modules/qemu/test_qemu_manager.py
@@ -50,7 +50,7 @@ def test_get_qemu_version(loop):
 
 def test_binary_list(loop):
 
-    files_to_create = ["qemu-system-x86", "qemu-system-x42", "qemu-kvm", "hello"]
+    files_to_create = ["qemu-system-x86", "qemu-system-x42", "qemu-kvm", "hello", "qemu-system-x86_64-spice"]
 
     for file_to_create in files_to_create:
         path = os.path.join(os.environ["PATH"], file_to_create)
@@ -70,6 +70,7 @@ def test_binary_list(loop):
         assert {"path": os.path.join(os.environ["PATH"], "qemu-kvm"), "version": version} in qemus
         assert {"path": os.path.join(os.environ["PATH"], "qemu-system-x42"), "version": version} in qemus
         assert {"path": os.path.join(os.environ["PATH"], "hello"), "version": version} not in qemus
+        assert {"path": os.path.join(os.environ["PATH"], "qemu-system-x86_64-spice"), "version": version} not in qemus
 
         qemus = loop.run_until_complete(asyncio.async(Qemu.binary_list(["x86"])))
 


### PR DESCRIPTION
It's create confusion and you can enable spice with the -spice
options.

Fix https://github.com/GNS3/gns3-gui/issues/981