### PR TITLE
updated docker command line processing

### DIFF
--- a/gns3server/modules/docker/docker_vm.py
+++ b/gns3server/modules/docker/docker_vm.py
@@ -195,16 +195,22 @@ class DockerVM(BaseVM):
             },
             "Volumes": {},
             "Env": [],
-            "Cmd": image_infos.get("ContainerConfig", {"Cmd": []})["Cmd"]
+            "Cmd": [],
+            "Entrypoint": image_infos.get("Config", {"Entrypoint": []})["Entrypoint"]
         }
 
-        params["Cmd"].insert(0, "/bin/sh")
-        params["Cmd"].insert(1, "/gns3/init.sh")
+
+        if params["Entrypoint"] is None:
+            params["Entrypoint"] = []
         if self._start_command:
-            params["Cmd"] += shlex.split(self._start_command)
-        else:
-            if len(params["Cmd"]) == 2:
-                params["Cmd"] += ["/bin/sh"]
+            params["Cmd"] = shlex.split(self._start_command)
+        if len(params["Cmd"]) == 0:
+            params["Cmd"] = image_infos.get("Config", {"Cmd": []})["Cmd"]
+            if params["Cmd"] is None:
+                params["Cmd"] = []
+        if len(params["Cmd"]) == 0 and len(params["Entrypoint"]) == 0:
+            params["Cmd"] = ["/bin/sh"]
+        params["Entrypoint"].insert(0, "/gns3/init.sh")
 
         if self._environment:
             params["Env"] += [e.strip() for e in self._environment.split("\n")]

--- a/gns3server/modules/docker/resources/init.sh
+++ b/gns3server/modules/docker/resources/init.sh
@@ -43,4 +43,4 @@ sed -n 's/^ *\(eth[0-9]*\):.*/\1/p' < /proc/net/dev | while read dev; do
 done
 
 # continue normal docker startup
-/bin/sh -c "$@"
+exec "$@"


### PR DESCRIPTION
Made the following changes:
- use image_infos.get("Config",...) instead of "ContainerConfig"
- init script injected before normal Entrypoint, so it's guaranteed to be the first command running
- init script has chmod +x, started without /bin/sh, because init script needs pid 1
- init script starts next script/program with exec, because (if it's a "real" init) it needs pid 1
- command line in GNS3 replaces command in docker, it's not appended. That's consistent with the "docker run" behavior
- A shell /bin/sh is only added, when Entrypoint and Cmd is empty