### PR TITLE
Minor cleanup on docker-init

### DIFF
--- a/gns3server/modules/docker/docker_vm.py
+++ b/gns3server/modules/docker/docker_vm.py
@@ -181,6 +181,8 @@ class DockerVM(BaseVM):
         os.makedirs(path, exist_ok=True)
         os.makedirs(os.path.join(path, "if-up.d"), exist_ok=True)
         os.makedirs(os.path.join(path, "if-down.d"), exist_ok=True)
+        os.makedirs(os.path.join(path, "if-pre-up.d"), exist_ok=True)
+        os.makedirs(os.path.join(path, "if-post-down.d"), exist_ok=True)
 
         if not os.path.exists(os.path.join(path, "interfaces")):
             with open(os.path.join(path, "interfaces"), "w+") as f:

--- a/gns3server/modules/docker/resources/bin/udhcpc
+++ b/gns3server/modules/docker/resources/bin/udhcpc
@@ -1,3 +1,0 @@
-#!/tmp/gns3/bin/sh
-
-exec busybox udhcpc -s /gns3/etc/udhcpc/default.script "$@"

--- a/gns3server/modules/docker/resources/bin/udhcpc6
+++ b/gns3server/modules/docker/resources/bin/udhcpc6
@@ -1,3 +1,0 @@
-#!/tmp/gns3/bin/sh
-
-exec busybox udhcpc6 -s /gns3/etc/udhcpc/default.script "$@"

--- a/gns3server/modules/docker/resources/init.sh
+++ b/gns3server/modules/docker/resources/init.sh
@@ -26,8 +26,6 @@ PATH=/gns3/bin:/tmp/gns3/bin
 if [ ! -d /tmp/gns3/bin ]; then
 	busybox mkdir -p /tmp/gns3/bin
 	/gns3/bin/busybox --install -s /tmp/gns3/bin
-	# remove commands already available in /gns3/bin
-	(cd /tmp/gns3/bin; rm -f `cd /gns3/bin; echo *`)
 fi
 
 # Wait 2 seconds to settle the network interfaces
@@ -47,12 +45,12 @@ __EOF__
 # configure loopback interface
 ip link set dev lo up
 
-# configure eth interfaces
+# activate eth interfaces
 sed -n 's/^ *\(eth[0-9]*\):.*/\1/p' < /proc/net/dev | while read dev; do
 	ip link set dev $dev up
 done
 
-
+# configure network interfaces
 ifup -a -f
 
 # continue normal docker startup


### PR DESCRIPTION
Some minor cleanup
- avoid warnings by adding /etc/network/pre-up.d and post-down.d
- shell wrappers for udhcpc and udhcpc6 no longer necessary, script path has been changed in busybox