### PR TITLE
Randomize port assignation

### DIFF
--- a/gns3server/modules/port_manager.py
+++ b/gns3server/modules/port_manager.py
@@ -17,6 +17,7 @@
 
 import socket
 import ipaddress
+import random
 from aiohttp.web import HTTPConflict
 from gns3server.config import Config
 
@@ -128,7 +129,7 @@ class PortManager:
         return self._used_udp_ports
 
     @staticmethod
-    def find_unused_port(start_port, end_port, host="127.0.0.1", socket_type="TCP", ignore_ports=[]):
+    def find_unused_port(start_port, end_port, host="127.0.0.1", socket_type="TCP", ignore_ports=set()):
         """
         Finds an unused port in a range.
 
@@ -143,10 +144,11 @@ class PortManager:
             raise HTTPConflict(text="Invalid port range {}-{}".format(start_port, end_port))
 
         last_exception = None
-        for port in range(start_port, end_port + 1):
-            if port in ignore_ports:
-                continue
-
+        ports = set(range(start_port, end_port + 1))
+        ports -= ignore_ports
+        ports = list(ports)
+        random.shuffle(ports)
+        for port in ports:
             try:
                 PortManager._check_port(host, port, socket_type)
                 return port

--- a/tests/handlers/api/test_network.py
+++ b/tests/handlers/api/test_network.py
@@ -22,7 +22,7 @@ import pytest
 def test_udp_allocation(server, project):
     response = server.post('/projects/{}/ports/udp'.format(project.id), {}, example=True)
     assert response.status == 201
-    assert response.json == {'udp_port': 10000}
+    assert 'udp_port' in response.json
 
 
 # Netfifaces is not available on Travis


### PR DESCRIPTION
Actually port are sequential this mean it's easy to got
conflict between projects or with different usage (example:
docker aux console is not saved to disk).

Fix #1154