### PR TITLE
Improve parse_version

### DIFF
--- a/gns3server/utils/__init__.py
+++ b/gns3server/utils/__init__.py
@@ -49,7 +49,7 @@ def int_to_macaddress(integer):
 
 def parse_version(version):
     """
-    Return a comparable tuple from a version string.
+    Return a comparable tuple from a version string. We try to force tuple to semver with version like 1.2.0
 
     Replace pkg_resources.parse_version which now display a warning when use for comparing version with tuple
 
@@ -64,13 +64,25 @@ def parse_version(version):
             continue
         try:
             info = int(info)
-            version.append(info)
+            # We pad with zero to compare only on string
+            # This avoid issue when comparing version with different length
+            version.append("%06d" % (info,))
         except ValueError:
+            # Force to a version with three number
+            if len(version) == 1:
+                version.append("00000")
+            if len(version) == 2:
+                version.append("000000")
             # We want rc to be at lower level than dev version
             if info == 'rc':
                 info = 'c'
             version.append(info)
             release_type_found = True
     if release_type_found is False:
+        # Force to a version with three number
+        if len(version) == 1:
+            version.append("00000")
+        if len(version) == 2:
+            version.append("000000")
         version.append("final")
     return tuple(version)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -34,11 +34,11 @@ def test_int_to_macaddress():
 
 
 def test_parse_version():
-    assert parse_version('1') == (1, 'final')
-    assert parse_version('1.3') == (1, 3, 'final')
-    assert parse_version('1.3.dev3') == (1, 3, 'dev', 3)
-    assert parse_version('1.3a1') == (1, 3, 'a', 1)
-    assert parse_version('1.3rc1') == (1, 3, 'c', 1)
+    assert parse_version('1') == ('000001', '00000', '000000', 'final')
+    assert parse_version('1.3') == ('000001', '000003', '000000', 'final')
+    assert parse_version('1.3.dev3') == ('000001', '000003', '000000', 'dev', '000003')
+    assert parse_version('1.3a1') == ('000001', '000003', '000000', 'a', '000001')
+    assert parse_version('1.3rc1') == ('000001', '000003', '000000', 'c', '000001')
 
     assert parse_version('1.2.3') > parse_version('1.2.2')
     assert parse_version('1.3') > parse_version('1.2.2')
@@ -46,3 +46,4 @@ def test_parse_version():
     assert parse_version('1.3') > parse_version('1.3rc1')
     assert parse_version('1.3rc1') > parse_version('1.3alpha3')
     assert parse_version('1.3dev1') > parse_version('1.3rc1')
+    assert parse_version('1.2.3') > parse_version('1.2')


### PR DESCRIPTION
What  do you think @grossmj ?  I think It should support most semantic version comparaison (problem you should not use the output to display it to a user)

I could backport it to GUI if it's ok

Ref #515 