### PR TITLE
Wait for all interfaces available in container

### DIFF
--- a/gns3server/modules/docker/docker_vm.py
+++ b/gns3server/modules/docker/docker_vm.py
@@ -284,6 +284,9 @@ class DockerVM(BaseVM):
             params["Cmd"] = ["/bin/sh"]
         params["Entrypoint"].insert(0, "/gns3/init.sh")
 
+        # Give the information to the container on how many interface should be inside
+        params["Env"].append("GNS3_MAX_ETHERNET=eth{}".format(self.adapters - 1))
+
         if self._environment:
             params["Env"] += [e.strip() for e in self._environment.split("\n")]
 

--- a/gns3server/modules/docker/resources/init.sh
+++ b/gns3server/modules/docker/resources/init.sh
@@ -28,9 +28,6 @@ if [ ! -d /tmp/gns3/bin ]; then
 	/gns3/bin/busybox --install -s /tmp/gns3/bin
 fi
 
-# Wait 2 seconds to settle the network interfaces
-sleep 2
-
 # /etc/hosts
 [ -s /etc/hosts ] || cat > /etc/hosts << __EOF__
 127.0.1.1	$HOSTNAME
@@ -44,6 +41,13 @@ __EOF__
 
 # configure loopback interface
 ip link set dev lo up
+
+# Wait for all eth available
+while true 
+do
+    grep $GNS3_MAX_ETHERNET /proc/net/dev > /dev/null && break
+    sleep 0.5
+done  
 
 # activate eth interfaces
 sed -n 's/^ *\(eth[0-9]*\):.*/\1/p' < /proc/net/dev | while read dev; do

--- a/tests/modules/docker/test_docker_vm.py
+++ b/tests/modules/docker/test_docker_vm.py
@@ -103,7 +103,9 @@ def test_create(loop, project, manager):
                 "Name": "test",
                 "Hostname": "test",
                 "Image": "ubuntu",
-                "Env": [],
+                "Env": [
+                    "GNS3_MAX_ETHERNET=eth0"
+                ],
                 "Entrypoint": ["/gns3/init.sh"],
                 "Cmd": ["/bin/sh"]
             })
@@ -142,7 +144,10 @@ def test_create_vnc(loop, project, manager):
                 "Name": "test",
                 "Hostname": "test",
                 "Image": "ubuntu",
-                "Env": ['DISPLAY=:42'],
+                "Env": [
+                    "GNS3_MAX_ETHERNET=eth0",
+                    "DISPLAY=:42"
+                ],
                 "Entrypoint": ["/gns3/init.sh"],
                 "Cmd": ["/bin/sh"]
             })
@@ -182,7 +187,9 @@ def test_create_start_cmd(loop, project, manager):
                 "Name": "test",
                 "Hostname": "test",
                 "Image": "ubuntu",
-                "Env": []
+                "Env": [
+                    "GNS3_MAX_ETHERNET=eth0"
+                ]
             })
         assert vm._cid == "e90e34656806"
 
@@ -211,7 +218,11 @@ def test_create_environment(loop, project, manager):
                         ],
                         "Privileged": True
                     },
-                "Env": ["YES=1", "NO=0"],
+                "Env": [
+                    "GNS3_MAX_ETHERNET=eth0",
+                    "YES=1",
+                    "NO=0"
+                ],
                 "Volumes": {},
                 "NetworkDisabled": True,
                 "Name": "test",
@@ -266,7 +277,9 @@ def test_create_image_not_available(loop, project, manager):
                 "Name": "test",
                 "Hostname": "test",
                 "Image": "ubuntu",
-                "Env": [],
+                "Env": [
+                    "GNS3_MAX_ETHERNET=eth0"
+                ],
                 "Entrypoint": ["/gns3/init.sh"],
                 "Cmd": ["/bin/sh"]
             })
@@ -481,7 +494,9 @@ def test_update(loop, vm):
         "Name": "test",
         "Hostname": "test",
         "Image": "ubuntu",
-        "Env": [],
+        "Env": [
+            "GNS3_MAX_ETHERNET=eth0"
+        ],
         "Entrypoint": ["/gns3/init.sh"],
         "Cmd": ["/bin/sh"]
     })
@@ -546,7 +561,9 @@ def test_update_running(loop, vm):
         "Name": "test",
         "Hostname": "test",
         "Image": "ubuntu",
-        "Env": [],
+        "Env": [
+            "GNS3_MAX_ETHERNET=eth0"
+        ],
         "Entrypoint": ["/gns3/init.sh"],
         "Cmd": ["/bin/sh"]
     })


### PR DESCRIPTION
Proposal improve for waiting that all the eth interface are available in the container.

Fix #511