### PR TITLE
Watch for dynamips rom & nvram change

### DIFF
--- a/gns3server/compute/dynamips/__init__.py
+++ b/gns3server/compute/dynamips/__init__.py
@@ -239,23 +239,6 @@ class Dynamips(BaseManager):
             if device.project.id == project.id:
                 yield from device.hypervisor.set_working_dir(project.module_working_directory(self.module_name.lower()))
 
-    @asyncio.coroutine
-    def project_committed(self, project):
-        """
-        Called when a project has been committed.
-
-        :param project: Project instance
-        """
-
-        # save the configs when the project is committed
-        for node in self._nodes.copy().values():
-            if node.project.id == project.id:
-                try:
-                    yield from node.save_configs()
-                except DynamipsError as e:
-                    log.warning(e)
-                    continue
-
     @property
     def dynamips_path(self):
         """

--- a/gns3server/compute/iou/iou_vm.py
+++ b/gns3server/compute/iou/iou_vm.py
@@ -503,7 +503,7 @@ class IOUVM(BaseNode):
             # check if there is enough RAM to run
             self.check_available_ram(self.ram)
 
-            self._nvram_watcher = FileWatcher(self._nvram_file(), self._nvram_changed)
+            self._nvram_watcher = FileWatcher(self._nvram_file(), self._nvram_changed, delay=10)
 
             # created a environment variable pointing to the iourc file.
             env = os.environ.copy()


### PR DESCRIPTION
This monitor for change the file from dynamips by computing a
hash of the watched file.

The way dynamips work prevent the update of the modification time.

We can improve that by using native system for watching file but:
* it's require dependencies specific for each OS
* dependencies use C extensions
* this is only a backup if your router is cleanly shutdown we export
stuff

Ref https://github.com/GNS3/gns3-gui/issues/1243