### PR TITLE
requirements.txt : added support for newer aiohttp version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jsonschema>=2.4.0
-aiohttp==0.21.5
+aiohttp>=0.21.5
 Jinja2>=2.7.3
 raven>=5.2.0
 psutil>=3.0.0


### PR DESCRIPTION
Rolling release distribution (like alpine linux), has the new aiohttp version., which is 0.22.1. This patch allow GNS3 to be installed with newer aiohttp, rahter than sticking to a specific version.
I've already applied it in porting GNS3 to Alpine : http://git.alpinelinux.org/cgit/aports/commit/?id=b71b64c26a38d5c9ec6e2692e4179bcd798c8ace
I had no issue so far, even if GNS3 is still in testing and needs thorugh check.
Thanks for considering!
Francesco Colista

