### PR TITLE
Updated systemd unit file and added sample configuration file

### DIFF
--- a/conf/gns3_server.conf
+++ b/conf/gns3_server.conf
@@ -1,0 +1,61 @@
+[Server]
+; IP where the server listen for connections
+host = 0.0.0.0
+; HTTP port for controlling the servers
+port = 3080
+
+; Option to enable SSL encryption
+ssl = False
+certfile=/home/gns3/.config/GNS3/ssl/server.cert
+certkey=/home/gns3/.config/GNS3/ssl/server.key
+
+; Path where devices images are stored
+images_path = /home/gns3/GNS3/images
+; Path where user projects are stored
+projects_path = /home/gns3/GNS3/projects
+
+; Option to automatically send crash reports to the GNS3 team
+report_errors = True
+
+; First console port of the range allocated to devices
+console_start_port_range = 2001
+; Last console port of the range allocated to devices
+console_end_port_range = 5000
+; First port of the range allocated for inter-device communication. Two ports are allocated per link.
+udp_start_port_range = 10000
+; Last port of the range allocated for inter-device communication. Two ports are allocated per link
+udp_start_end_range = 20000
+; uBridge executable location
+ubridge_path = /Applications/GNS3.app/Contents/Resources/ubridge
+
+; Option to enable HTTP authentication.
+auth = True
+; Username for HTTP authentication.
+user = gns3
+; Password for HTTP authentication.
+password = gns3
+
+[VPCS]
+; VPCS executable location
+vpcs_path = /usr/bin/vpcs
+
+[Dynamips]
+; Enable auxiliary console ports on IOS routers
+allocate_aux_console_ports = False
+mmap_support = True
+; Dynamips executable path
+dynamips_path = /usr/bin/dynamips
+sparse_memory_support = True
+ghost_ios_support = True
+
+[IOU]
+; iouyap executable path
+iouyap_path = /usr/bin/iouyap
+; Path of your .iourc file. If not provided, the file is searched in $HOME/.iourc
+iourc_path = /home/gns3/.iourc
+; Validate if the iourc license file is correct. If you turn this off and your licence is invalid IOU will not start and no errors will be shown.
+license_check = True
+
+[Qemu]
+; !! Remember to add the gns3 user to the KVM group, otherwise you will not have read / write permssions to /dev/kvm !!
+enable_kvm = True

--- a/init/gns3.service.systemd
+++ b/init/gns3.service.systemd
@@ -3,12 +3,14 @@ Description=GNS3 server
 
 [Service]
 Type=forking
-Environment=statedir=/var/cache/gns3
-PIDFile=/var/run/gns3.pid
-ExecStart=/usr/local/bin/gns3server --log /var/log/gns3.log \
- --pid /var/run/gns3.pid --daemon
-Restart=on-abort
 User=gns3
+Group=gns3
+PermissionsStartOnly=true
+ExecStartPre=/bin/mkdir /var/run/gns3
+ExecStartPre=/bin/chown -R gns3:gns3 /var/run/gns3/
+ExecStart=/usr/share/gns3/gns3-server/bin/gns3server --log /var/log/gns3/gns3.log --pid /var/run/gns3/gns3.pid --daemon
+Restart=on-abort
+PIDFile=/var/run/gns3/gns3-server.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Rewrote the systemd unit file to fix an issue where the system was not able to create a PID file inside /var/run.

I fixed this by having systemd create a new directory called /var/run/gns3. Then I had systemd change ownership of the directory to gns3:gns3 so the gns3server executable could read and write the PID file. I have tested these changes against Ubuntu 16.04.1 LTS.