### PR TITLE
Bind qemu UDP tunnels on all hosts

### DIFF
--- a/gns3server/compute/qemu/qemu_vm.py
+++ b/gns3server/compute/qemu/qemu_vm.py
@@ -1098,8 +1098,8 @@ class QemuVM(BaseNode):
 
         if self.ubridge and self.ubridge.is_running():
             yield from self._add_ubridge_udp_connection("QEMU-{}-{}".format(self._id, adapter_number),
-                                                         self._local_udp_tunnels[adapter_number][1],
-                                                         nio)
+                                                        self._local_udp_tunnels[adapter_number][1],
+                                                        nio)
         elif self.is_running():
             raise QemuError("Sorry, adding a link to a started Qemu VM is not supported without using uBridge.")
 
@@ -1202,6 +1202,7 @@ class QemuVM(BaseNode):
         log.info("QEMU VM '{name}' [{id}]: stopping packet capture on adapter {adapter_number}".format(name=self.name,
                                                                                                        id=self.id,
                                                                                                        adapter_number=adapter_number))
+
     @property
     def started(self):
         """
@@ -1419,7 +1420,7 @@ class QemuVM(BaseNode):
                                                                                                                            adapter_number,
                                                                                                                            nio.rhost,
                                                                                                                            nio.rport,
-                                                                                                                           self._host,
+                                                                                                                           "0.0.0.0",
                                                                                                                            nio.lport)])
                     elif isinstance(nio, NIOTAP):
                         network_options.extend(["-net", "tap,name=gns3-{},ifname={}".format(adapter_number, nio.tap_device)])


### PR DESCRIPTION
Qemu is the only platform where we limit the binding of UDP
tunnel to a specific host. It's probably much secure and cleaner
but we have scenario where we need one port bind to an IP and
another bind to a different IP (Link between qemu and and a VM on the
GNS3 VM)

This allow the use of 134fed8fc5d5f130275a7a1f19613427548ceb57