### PR TITLE
When checking for a free port check if the host and 0.0.0.0 are available

### DIFF
--- a/gns3server/modules/port_manager.py
+++ b/gns3server/modules/port_manager.py
@@ -153,6 +153,8 @@ class PortManager:
 
             try:
                 PortManager._check_port(host, port, socket_type)
+                if host != "0.0.0.0":
+                    PortManager._check_port("0.0.0.0", port, socket_type)
                 return port
             except OSError as e:
                 last_exception = e


### PR DESCRIPTION
Because some emulators will listen on 0.0.0.0 and not on the host.

Fix #721