### PR TITLE
typing is already included in Python >= 3.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ jsonschema>=2.4.0
 aiohttp==1.2.0 # pyup: ignore
 aiohttp-cors==0.4.0 # pyup: ignore
 yarl==0.8.1 # pyup: ignore
-typing>=3.5.3.0 # Otherwise yarl fail with python 3.4 
 Jinja2>=2.7.3
 raven>=5.23.0
 psutil>=3.0.0

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,9 @@ class PyTest(TestCommand):
 
 dependencies = open("requirements.txt", "r").read().splitlines()
 
+if sys.version_info <= (3, 4):
+    dependencies.append('typing>=3.5.3.0 # Otherwise yarl fail with python 3.4')
+
 setup(
     name="gns3-server",
     version=__import__("gns3server").__version__,


### PR DESCRIPTION
typing is now part of Python starting from 3.5, this PR exclude this requirement on such version.