### PR TITLE
NAT node can use the VMware NAT

### DIFF
--- a/gns3server/compute/builtin/nodes/nat.py
+++ b/gns3server/compute/builtin/nodes/nat.py
@@ -30,14 +30,21 @@ class Nat(Cloud):
     """
 
     def __init__(self, *args, **kwargs):
-        if "virbr0" not in [interface["name"] for interface in gns3server.utils.interfaces.interfaces()]:
-            raise NodeError("virbr0 is missing. You need to install libvirt")
+
+        if sys.platform.startswith("linux"):
+            if "virbr0" not in [interface["name"] for interface in gns3server.utils.interfaces.interfaces()]:
+                raise NodeError("virbr0 is missing. You need to install libvirt")
+            interface = "virbr0"
+        else:
+            if "vmnet8" not in [interface["name"] for interface in gns3server.utils.interfaces.interfaces()]:
+                raise NodeError("vmnet8 is missing. You need to install VMware or use the NAT node on GNS3 VM")
+            interface = "vmnet8"
 
         ports = [
             {
                 "name": "nat0",
                 "type": "ethernet",
-                "interface": "virbr0",
+                "interface": interface,
                 "port_number": 0
             }
         ]
@@ -54,7 +61,7 @@ class Nat(Cloud):
 
     @classmethod
     def is_supported(self):
-        return sys.platform.startswith("linux")
+        return True
 
     def __json__(self):
         return {

--- a/tests/compute/builtin/nodes/test_nat.py
+++ b/tests/compute/builtin/nodes/test_nat.py
@@ -17,14 +17,12 @@
 
 import uuid
 import pytest
-from unittest.mock import MagicMock
-from tests.utils import asyncio_patch
+from unittest.mock import MagicMock, patch
 
 from gns3server.compute.builtin.nodes.nat import Nat
-from gns3server.compute.vpcs import VPCS
 
 
-def test_json(on_gns3vm, project):
+def test_json_gns3vm(on_gns3vm, project):
     nat = Nat("nat1", str(uuid.uuid4()), project, MagicMock())
     assert nat.__json__() == {
         "name": "nat1",
@@ -34,6 +32,27 @@ def test_json(on_gns3vm, project):
         "ports_mapping": [
             {
                 "interface": "virbr0",
+                "name": "nat0",
+                "port_number": 0,
+                "type": "ethernet"
+            }
+        ]
+    }
+
+
+def test_json_darwin(darwin_platform, project):
+    with patch("gns3server.utils.interfaces.interfaces", return_value=[
+            {"name": "eth0", "special": False, "type": "ethernet"},
+            {"name": "vmnet8", "special": True, "type": "ethernet"}]):
+        nat = Nat("nat1", str(uuid.uuid4()), project, MagicMock())
+    assert nat.__json__() == {
+        "name": "nat1",
+        "node_id": nat.id,
+        "project_id": project.id,
+        "status": "started",
+        "ports_mapping": [
+            {
+                "interface": "vmnet8",
                 "name": "nat0",
                 "port_number": 0,
                 "type": "ethernet"

--- a/tests/handlers/api/compute/test_capabilities.py
+++ b/tests/handlers/api/compute/test_capabilities.py
@@ -29,12 +29,9 @@ from gns3server.version import __version__
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Not supported on Windows")
 def test_get(http_compute, windows_platform):
-    """
-    Nat, is supported outside linux
-    """
     response = http_compute.get('/capabilities', example=True)
     assert response.status == 200
-    assert response.json == {'node_types': ['cloud', 'ethernet_hub', 'ethernet_switch', 'vpcs', 'virtualbox', 'dynamips', 'frame_relay_switch', 'atm_switch', 'qemu', 'vmware', 'docker', 'iou'], 'version': __version__, 'platform': sys.platform}
+    assert response.json == {'node_types': ['cloud', 'ethernet_hub', 'ethernet_switch', 'nat', 'vpcs', 'virtualbox', 'dynamips', 'frame_relay_switch', 'atm_switch', 'qemu', 'vmware', 'docker', 'iou'], 'version': __version__, 'platform': sys.platform}
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Not supported on Windows")


### PR DESCRIPTION
On Windows and Mac OS this allow the NAT node to use the
VMware nat (it's always vmnet8). On Linux we still use the
libvirt NAT