### PR TITLE
Test if a snapshot name already exists

### DIFF
--- a/gns3server/controller/project.py
+++ b/gns3server/controller/project.py
@@ -510,6 +510,9 @@ class Project:
         :param name: Name of the snapshot
         """
 
+        if name in [snap.name for snap in self.snapshots.values()]:
+            raise aiohttp.web_exceptions.HTTPConflict(text="The snapshot {} already exist".format(name))
+
         snapshot = Snapshot(self, name=name)
         try:
             if os.path.exists(snapshot.path):


### PR DESCRIPTION
This fix random test failure when testing snapshots. It
seem under high load sometimes the previous snapshot folder
was not visible on disk. Perhaps a test isolation issue but
I don't see how.

But in any case it's better to test if the name is not already
use.

Fix #1118