### PR TITLE
QEMU: fix logging of base mac address when creating a new node

### DIFF
--- a/gns3server/compute/qemu/qemu_vm.py
+++ b/gns3server/compute/qemu/qemu_vm.py
@@ -537,7 +537,7 @@ class QemuVM(BaseNode):
 
         log.info('QEMU VM "{name}" [{id}]: MAC address changed to {mac_addr}'.format(name=self._name,
                                                                                      id=self._id,
-                                                                                     mac_addr=mac_address))
+                                                                                     mac_addr=self._mac_address))
 
     @property
     def legacy_networking(self):


### PR DESCRIPTION
gns3 server log doesn't show the base MAC address when creating a new qemu node (i.e when the mac address is auto-generated).