### PR TITLE
Rename ethernet switch shell command arp to mac

### DIFF
--- a/gns3server/compute/dynamips/nodes/ethernet_switch.py
+++ b/gns3server/compute/dynamips/nodes/ethernet_switch.py
@@ -44,9 +44,9 @@ class EthernetSwitchConsole(EmbedShell):
         self._node = node
 
     @asyncio.coroutine
-    def arp(self):
+    def mac(self):
         """
-        Show arp table
+        Show MAC address table
         """
         res = 'Port       Mac                VLAN\n'
         result = (yield from self._node._hypervisor.send('ethsw show_mac_addr_table {}'.format(self._node.name)))

--- a/tests/compute/dynamips/test_ethernet_switch.py
+++ b/tests/compute/dynamips/test_ethernet_switch.py
@@ -20,7 +20,7 @@ from gns3server.compute.dynamips.nodes.ethernet_switch import EthernetSwitchCons
 from gns3server.compute.nios.nio_udp import NIOUDP
 
 
-def test_arp_command(async_run):
+def test_mac_command(async_run):
     node = AsyncioMagicMock()
     node.name = "Test"
     node.nios = {}
@@ -30,7 +30,7 @@ def test_arp_command(async_run):
     node.nios[1].name = "Ethernet1"
     node._hypervisor.send = AsyncioMagicMock(return_value=["0050.7966.6801  1  Ethernet0", "0050.7966.6802  1  Ethernet1"])
     console = EthernetSwitchConsole(node)
-    assert async_run(console.arp()) == \
+    assert async_run(console.mac()) == \
         "Port       Mac                VLAN\n" \
         "Ethernet0  00:50:79:66:68:01  1\n" \
         "Ethernet1  00:50:79:66:68:02  1\n"


### PR DESCRIPTION
From https://gns3.com/qa/ethernet-switch-incorrectly-has-