### PR TITLE
Update remote-install.sh

### DIFF
--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -259,6 +259,8 @@ else
     cat <<EOFI > /lib/systemd/system/gns3.service
 [Unit]
 Description=GNS3 server
+Wants=network-online.target
+After=network.target network-online.target
 
 [Service]
 Type=forking
@@ -267,8 +269,8 @@ Group=gns3
 PermissionsStartOnly=true
 ExecStartPre=/bin/mkdir -p /var/log/gns3 /var/run/gns3
 ExecStartPre=/bin/chown -R gns3:gns3 /var/log/gns3 /var/run/gns3
-ExecStart=/usr/bin/gns3server --log /var/log/gns3/gns3.log \
-     --pid /var/run/gns3/gns3.pid --daemon
+ExecStart=/usr/local/bin/gns3server --log /var/log/gns3/gns3.log \
+ --pid /var/run/gns3/gns3.pid --daemon
 Restart=on-abort
 PIDFile=/var/run/gns3/gns3.pid
 


### PR DESCRIPTION
Updated systemd config

it seems that the install script tends to use a different config when the ubuntu distribution is not trusty. In my case, I observed gns3 was installed in /usr/local/bin but the config tends to look up in /usr/bin/gns3server. Additionally https://github.com/GNS3/gns3-server/issues/851 this issue would also pop up due to early start of the gns3 service in the boot process