### PR TITLE
Hold prompt-toolkit==1.0.15 to fix https://github.com/GNS3/gns3-serve…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ raven>=5.23.0
 psutil>=3.0.0
 zipstream>=1.1.4
 typing>=3.5.3.0 # Otherwise yarl fails with python 3.4
-prompt-toolkit
+prompt-toolkit==1.0.15


### PR DESCRIPTION
This little change solve runtime error due the prompt-toolkit update to version 2, so it holds version 1.0.15