### PR TITLE
Require typing only for Python < 3.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ Jinja2>=2.7.3
 raven>=5.23.0
 psutil>=3.0.0
 zipstream>=1.1.4
-typing>=3.5.3.0 # Otherwise yarl fails with python 3.4
+typing>=3.5.3.0;python_version<"3.5" # Otherwise yarl fails with python 3.4
 prompt-toolkit==1.0.15


### PR DESCRIPTION
Hi,
The typing package is already included in Python 3.5 and later and it can apparently cause failures for Python 3.7.