### PR TITLE
Allow virtual machines to use files in project directory as disk images

### DIFF
--- a/gns3server/compute/dynamips/nodes/router.py
+++ b/gns3server/compute/dynamips/nodes/router.py
@@ -169,8 +169,7 @@ class Router(BaseNode):
                        "mac_addr": self._mac_addr,
                        "system_id": self._system_id}
 
-        # return the relative path if the IOS image is in the images_path directory
-        router_info["image"] = self.manager.get_relative_image_path(self._image)
+        router_info["image"] = self._image
 
         # add the slots
         slot_number = 0
@@ -496,7 +495,7 @@ class Router(BaseNode):
         :param image: path to IOS image file
         """
 
-        image = self.manager.get_abs_image_path(image)
+        image = self.manager.get_abs_image_path(image, self.project.path)
 
         yield from self._hypervisor.send('vm set_ios "{name}" "{image}"'.format(name=self._name, image=image))
 

--- a/gns3server/compute/iou/iou_vm.py
+++ b/gns3server/compute/iou/iou_vm.py
@@ -74,7 +74,7 @@ class IOUVM(BaseNode):
         self._iou_stdout_file = ""
         self._started = False
         self._nvram_watcher = None
-        self._path = self.manager.get_abs_image_path(path)
+        self._path = self.manager.get_abs_image_path(path, project.path)
 
         # IOU settings
         self._ethernet_adapters = []
@@ -136,7 +136,7 @@ class IOUVM(BaseNode):
         :param path: path to the IOU image executable
         """
 
-        self._path = self.manager.get_abs_image_path(path)
+        self._path = self.manager.get_abs_image_path(path, self.project.path)
         log.info('IOU "{name}" [{id}]: IOU image updated to "{path}"'.format(name=self._name, id=self._id, path=self._path))
 
     @property
@@ -233,8 +233,7 @@ class IOUVM(BaseNode):
                        "command_line": self.command_line,
                        "application_id": self.application_id}
 
-        # return the relative path if the IOU image is in the images_path directory
-        iou_vm_info["path"] = self.manager.get_relative_image_path(self.path)
+        iou_vm_info["path"] = self.path
         return iou_vm_info
 
     @property

--- a/gns3server/compute/qemu/qemu_vm.py
+++ b/gns3server/compute/qemu/qemu_vm.py
@@ -207,7 +207,7 @@ class QemuVM(BaseNode):
         :param variable: Variable name in the class
         :param value: New disk value
         """
-        value = self.manager.get_abs_image_path(value)
+        value = self.manager.get_abs_image_path(value, self.project.path)
         if not self.linked_clone:
             for node in self.manager.nodes:
                 if node != self and getattr(node, variable) == value:
@@ -406,7 +406,7 @@ class QemuVM(BaseNode):
 
         :param cdrom_image: QEMU cdrom image path
         """
-        self._cdrom_image = self.manager.get_abs_image_path(cdrom_image)
+        self._cdrom_image = self.manager.get_abs_image_path(cdrom_image, self.project.path)
         log.info('QEMU VM "{name}" [{id}] has set the QEMU cdrom image path to {cdrom_image}'.format(name=self._name,
                                                                                                      id=self._id,
                                                                                                      cdrom_image=self._cdrom_image))
@@ -428,7 +428,7 @@ class QemuVM(BaseNode):
 
         :param bios_image: QEMU bios image path
         """
-        self._bios_image = self.manager.get_abs_image_path(bios_image)
+        self._bios_image = self.manager.get_abs_image_path(bios_image, self.project.path)
         log.info('QEMU VM "{name}" [{id}] has set the QEMU bios image path to {bios_image}'.format(name=self._name,
                                                                                                    id=self._id,
                                                                                                    bios_image=self._bios_image))
@@ -731,7 +731,7 @@ class QemuVM(BaseNode):
         :param initrd: QEMU initrd path
         """
 
-        initrd = self.manager.get_abs_image_path(initrd)
+        initrd = self.manager.get_abs_image_path(initrd, self.project.path)
 
         log.info('QEMU VM "{name}" [{id}] has set the QEMU initrd path to {initrd}'.format(name=self._name,
                                                                                            id=self._id,
@@ -758,7 +758,7 @@ class QemuVM(BaseNode):
         :param kernel_image: QEMU kernel image path
         """
 
-        kernel_image = self.manager.get_abs_image_path(kernel_image)
+        kernel_image = self.manager.get_abs_image_path(kernel_image, self.project.path)
         log.info('QEMU VM "{name}" [{id}] has set the QEMU kernel image path to {kernel_image}'.format(name=self._name,
                                                                                                        id=self._id,
                                                                                                        kernel_image=kernel_image))
@@ -1698,22 +1698,22 @@ class QemuVM(BaseNode):
                     answer[field] = getattr(self, field)
                 except AttributeError:
                     pass
-        answer["hda_disk_image"] = self.manager.get_relative_image_path(self._hda_disk_image)
+        answer["hda_disk_image"] = self._hda_disk_image
         answer["hda_disk_image_md5sum"] = md5sum(self._hda_disk_image)
-        answer["hdb_disk_image"] = self.manager.get_relative_image_path(self._hdb_disk_image)
+        answer["hdb_disk_image"] = self._hdb_disk_image
         answer["hdb_disk_image_md5sum"] = md5sum(self._hdb_disk_image)
-        answer["hdc_disk_image"] = self.manager.get_relative_image_path(self._hdc_disk_image)
+        answer["hdc_disk_image"] = self._hdc_disk_image
         answer["hdc_disk_image_md5sum"] = md5sum(self._hdc_disk_image)
-        answer["hdd_disk_image"] = self.manager.get_relative_image_path(self._hdd_disk_image)
+        answer["hdd_disk_image"] = self._hdd_disk_image
         answer["hdd_disk_image_md5sum"] = md5sum(self._hdd_disk_image)
-        answer["cdrom_image"] = self.manager.get_relative_image_path(self._cdrom_image)
+        answer["cdrom_image"] = self._cdrom_image
         answer["cdrom_image_md5sum"] = md5sum(self._cdrom_image)
-        answer["bios_image"] = self.manager.get_relative_image_path(self._bios_image)
+        answer["bios_image"] = self._bios_image
         answer["bios_image_md5sum"] = md5sum(self._bios_image)
-        answer["initrd"] = self.manager.get_relative_image_path(self._initrd)
+        answer["initrd"] = self._initrd
         answer["initrd_md5sum"] = md5sum(self._initrd)
 
-        answer["kernel_image"] = self.manager.get_relative_image_path(self._kernel_image)
+        answer["kernel_image"] = self._kernel_image
         answer["kernel_image_md5sum"] = md5sum(self._kernel_image)
 
         return answer


### PR DESCRIPTION
This is useful for Cisco VMs that will load a boot configuration if it appears on an ISO filesystem attached as a virtual CD-ROM, and boot configurations are logically part of the project, not global.

Part of this change is that the server no longer tries to relativize the paths before returning them in JSON objects, since there's no longer a single directory to relativize against, as the filenames can be relative to either the image directory or the project directory.  So we just return the pathnames as is.

There might be a security issue here, as this allows clients to upload arbitrary images and boot them into virtual machines.  However, I think the client can already do that, since new appliances get copied up from the client.
