### PR TITLE
Support for using other dhcp clients in docker init.sh

### DIFF
--- a/gns3server/compute/docker/resources/init.sh
+++ b/gns3server/compute/docker/resources/init.sh
@@ -20,7 +20,7 @@
 # the start command of the container
 #
 OLD_PATH="$PATH"
-PATH=/gns3/bin:/tmp/gns3/bin
+PATH=/gns3/bin:/tmp/gns3/bin:/sbin
 
 # bootstrap busybox commands
 if [ ! -d /tmp/gns3/bin ]; then


### PR DESCRIPTION
Added `/sbin` to init script PATH variable so that its possible to use more sophisticated DHCP clients (compared to the udhcpc that is provided by busybox) by installing them into the docker image in the normal way.

This was done so that it was possible to set the client-id for DHCP by using dhclient installed into the docker image. The precedence is defined as follows:
> Clients are tried in the following order: dhcpcd, dhclient, pump and udhcpc.

The `interfaces` file configured within GNS3 for the docker image could then contain the following:
```
auto eth0
iface eth0 inet dhcp
	pre-up echo "send dhcp-client-identifier 0:67:6e:73:33;"  > /etc/dhcp/dhclient.conf
```
That will set the client id to `gns3`.