### PR TITLE
Docker: fix x11vnc not starting

### DIFF
--- a/gns3server/compute/docker/docker_vm.py
+++ b/gns3server/compute/docker/docker_vm.py
@@ -548,7 +548,7 @@ class DockerVM(BaseNode):
             with open(os.path.join(self.working_dir, "vnc.log"), "w") as fd:
                 self._vnc_process = yield from asyncio.create_subprocess_exec("x11vnc",
                                                                               "-forever",
-                                                                              "-nopw"
+                                                                              "-nopw",
                                                                               "-shared",
                                                                               "-geometry", self._console_resolution,
                                                                               "-display", "WAIT:{}".format(self._display),


### PR DESCRIPTION
x11vnc fails to start because of a typo:

vnc.log:
29/11/2018 00:24:06 *** unrecognized option(s) ***
29/11/2018 00:24:06 	[1]  -nopw-shared