### PR TITLE
Support for docker images that set the USER directive

### DIFF
--- a/gns3server/compute/docker/docker_vm.py
+++ b/gns3server/compute/docker/docker_vm.py
@@ -311,6 +311,7 @@ class DockerVM(BaseNode):
             "Tty": True,
             "OpenStdin": True,
             "StdinOnce": False,
+            "User": "root",
             "HostConfig": {
                 "CapAdd": ["ALL"],
                 "Privileged": True,
@@ -341,6 +342,9 @@ class DockerVM(BaseNode):
         params["Env"].append("GNS3_MAX_ETHERNET=eth{}".format(self.adapters - 1))
         # Give the information to the container the list of volume path mounted
         params["Env"].append("GNS3_VOLUMES={}".format(":".join(self._volumes)))
+
+        # Pass user configured for image to init script
+        params["Env"].append("GNS3_USER={}".format(image_infos.get("Config", {"User": ""})["User"]))
 
         variables = self.project.variables
         if not variables:

--- a/gns3server/compute/docker/resources/init.sh
+++ b/gns3server/compute/docker/resources/init.sh
@@ -87,6 +87,9 @@ done
 ifup -a -f
 
 # continue normal docker startup
-PATH="$OLD_PATH"
-exec "$@"
-
+GNS3_CMD="PATH=$OLD_PATH exec"
+while test "$#" -gt 0 ; do
+    GNS3_CMD="${GNS3_CMD} \"${1//\"/\\\"}\""
+    shift
+done
+exec su ${GNS3_USER-root} -p -c "$GNS3_CMD"


### PR DESCRIPTION
Some docker images explicitly set the [runtime user](https://docs.docker.com/engine/reference/builder/#user) such as [graylog](https://hub.docker.com/r/graylog/graylog/). This means that the `init.sh` script used by gns3 inside docker will not work as it need root permissions.

This patch starts the container with root user, then uses `su` to drop to the desired user (or root if no user was configured) after `init.sh` has finished.

The `init.sh` has a little additional complexity to handle nested arguments, such as the convoluted example:
```
            "Cmd": [
                "/bin/sh",
                "-c",
                "cd /etc ; pwd ; exec /bin/sh -c \"cd /etc/network ; pwd ; exec /bin/sh\""
            ],
```
Please feel free to update if there is a better way to handle these cases.