### PR TITLE
Custom persistent docker volumes

### DIFF
--- a/gns3server/handlers/api/compute/docker_handler.py
+++ b/gns3server/handlers/api/compute/docker_handler.py
@@ -61,7 +61,8 @@ class DockerHandler:
                                                           console_http_port=request.json.get("console_http_port", 80),
                                                           console_http_path=request.json.get("console_http_path", "/"),
                                                           aux=request.json.get("aux"),
-                                                          extra_hosts=request.json.get("extra_hosts"))
+                                                          extra_hosts=request.json.get("extra_hosts"),
+                                                          extra_volumes=request.json.get("extra_volumes"))
         for name, value in request.json.items():
             if name != "node_id":
                 if hasattr(container, name) and getattr(container, name) != value:
@@ -316,7 +317,7 @@ class DockerHandler:
         props = [
             "name", "console", "aux", "console_type", "console_resolution",
             "console_http_port", "console_http_path", "start_command",
-            "environment", "adapters", "extra_hosts"
+            "environment", "adapters", "extra_hosts", "extra_volumes"
         ]
 
         changed = False

--- a/gns3server/schemas/docker.py
+++ b/gns3server/schemas/docker.py
@@ -95,6 +95,14 @@ DOCKER_CREATE_SCHEMA = {
             "type": ["string", "null"],
             "minLength": 0,
         },
+        "extra_volumes": {
+            "description": "Additional directories to make persistent",
+            "type": "array",
+            "minItems": 0,
+            "items": {
+                "type": "string"
+            }
+        },
         "container_id": {
             "description": "Docker container ID Read only",
             "type": "string",
@@ -197,6 +205,14 @@ DOCKER_OBJECT_SCHEMA = {
             "description": "Docker extra hosts (added to /etc/hosts)",
             "type": ["string", "null"],
             "minLength": 0,
+        },
+        "extra_volumes": {
+            "description": "Additional directories to make persistent",
+            "type": "array",
+            "minItems": 0,
+            "items": {
+                "type": "string",
+            }
         },
         "node_directory": {
             "description": "Path to the node working directory  Read only",

--- a/tests/compute/docker/test_docker_vm.py
+++ b/tests/compute/docker/test_docker_vm.py
@@ -483,6 +483,18 @@ def test_create_with_extra_volumes_invalid_format_2(loop, project, manager):
             with pytest.raises(DockerError):
                 loop.run_until_complete(asyncio.ensure_future(vm.create()))
 
+def test_create_with_extra_volumes_invalid_format_3(loop, project, manager):
+
+    response = {
+        "Id": "e90e34656806",
+        "Warnings": []
+    }
+    with asyncio_patch("gns3server.compute.docker.Docker.list_images", return_value=[{"image": "ubuntu"}]) as mock_list_images:
+        with asyncio_patch("gns3server.compute.docker.Docker.query", return_value=response) as mock:
+            vm = DockerVM("test", str(uuid.uuid4()), project, manager, "ubuntu:latest", extra_volumes=["/vol1/.."])
+            with pytest.raises(DockerError):
+                loop.run_until_complete(asyncio.ensure_future(vm.create()))
+
 def test_create_with_extra_volumes_duplicate_1_image(loop, project, manager):
 
     response = {
@@ -509,6 +521,30 @@ def test_create_with_extra_volumes_duplicate_2_user(loop, project, manager):
     with asyncio_patch("gns3server.compute.docker.Docker.list_images", return_value=[{"image": "ubuntu"}]) as mock_list_images:
         with asyncio_patch("gns3server.compute.docker.Docker.query", return_value=response) as mock:
             vm = DockerVM("test", str(uuid.uuid4()), project, manager, "ubuntu:latest", extra_volumes=["/vol/1", "/vol/1"])
+            with pytest.raises(DockerError):
+                loop.run_until_complete(asyncio.ensure_future(vm.create()))
+
+def test_create_with_extra_volumes_duplicate_3_subdir(loop, project, manager):
+
+    response = {
+        "Id": "e90e34656806",
+        "Warnings": [],
+    }
+    with asyncio_patch("gns3server.compute.docker.Docker.list_images", return_value=[{"image": "ubuntu"}]) as mock_list_images:
+        with asyncio_patch("gns3server.compute.docker.Docker.query", return_value=response) as mock:
+            vm = DockerVM("test", str(uuid.uuid4()), project, manager, "ubuntu:latest", extra_volumes=["/vol/1/", "/vol"])
+            with pytest.raises(DockerError):
+                loop.run_until_complete(asyncio.ensure_future(vm.create()))
+
+def test_create_with_extra_volumes_duplicate_4_backslash(loop, project, manager):
+
+    response = {
+        "Id": "e90e34656806",
+        "Warnings": [],
+    }
+    with asyncio_patch("gns3server.compute.docker.Docker.list_images", return_value=[{"image": "ubuntu"}]) as mock_list_images:
+        with asyncio_patch("gns3server.compute.docker.Docker.query", return_value=response) as mock:
+            vm = DockerVM("test", str(uuid.uuid4()), project, manager, "ubuntu:latest", extra_volumes=["/vol//", "/vol"])
             with pytest.raises(DockerError):
                 loop.run_until_complete(asyncio.ensure_future(vm.create()))
 

--- a/tests/compute/docker/test_docker_vm.py
+++ b/tests/compute/docker/test_docker_vm.py
@@ -62,6 +62,7 @@ def test_json(vm, project):
         'console_http_port': 80,
         'console_http_path': '/',
         'extra_hosts': None,
+        'extra_volumes': [],
         'aux': vm.aux,
         'start_command': vm.start_command,
         'environment': vm.environment,
@@ -452,6 +453,104 @@ def test_create_with_user(loop, project, manager):
                     "GNS3_MAX_ETHERNET=eth0",
                     "GNS3_VOLUMES=/etc/network",
                     "GNS3_USER=test"
+                    ],
+                "Entrypoint": ["/gns3/init.sh"],
+                "Cmd": ["/bin/sh"]
+            })
+        assert vm._cid == "e90e34656806"
+
+def test_create_with_extra_volumes_invalid_format_1(loop, project, manager):
+
+    response = {
+        "Id": "e90e34656806",
+        "Warnings": []
+    }
+    with asyncio_patch("gns3server.compute.docker.Docker.list_images", return_value=[{"image": "ubuntu"}]) as mock_list_images:
+        with asyncio_patch("gns3server.compute.docker.Docker.query", return_value=response) as mock:
+            vm = DockerVM("test", str(uuid.uuid4()), project, manager, "ubuntu:latest", extra_volumes=["vol1"])
+            with pytest.raises(DockerError):
+                loop.run_until_complete(asyncio.ensure_future(vm.create()))
+
+def test_create_with_extra_volumes_invalid_format_2(loop, project, manager):
+
+    response = {
+        "Id": "e90e34656806",
+        "Warnings": []
+    }
+    with asyncio_patch("gns3server.compute.docker.Docker.list_images", return_value=[{"image": "ubuntu"}]) as mock_list_images:
+        with asyncio_patch("gns3server.compute.docker.Docker.query", return_value=response) as mock:
+            vm = DockerVM("test", str(uuid.uuid4()), project, manager, "ubuntu:latest", extra_volumes=["/vol1", ""])
+            with pytest.raises(DockerError):
+                loop.run_until_complete(asyncio.ensure_future(vm.create()))
+
+def test_create_with_extra_volumes_duplicate_1_image(loop, project, manager):
+
+    response = {
+        "Id": "e90e34656806",
+        "Warnings": [],
+        "Config" : {
+            "Volumes" : {
+                "/vol/1": None
+            },
+        },
+    }
+    with asyncio_patch("gns3server.compute.docker.Docker.list_images", return_value=[{"image": "ubuntu"}]) as mock_list_images:
+        with asyncio_patch("gns3server.compute.docker.Docker.query", return_value=response) as mock:
+            vm = DockerVM("test", str(uuid.uuid4()), project, manager, "ubuntu:latest", extra_volumes=["/vol/1"])
+            with pytest.raises(DockerError):
+                loop.run_until_complete(asyncio.ensure_future(vm.create()))
+
+def test_create_with_extra_volumes_duplicate_2_user(loop, project, manager):
+
+    response = {
+        "Id": "e90e34656806",
+        "Warnings": [],
+    }
+    with asyncio_patch("gns3server.compute.docker.Docker.list_images", return_value=[{"image": "ubuntu"}]) as mock_list_images:
+        with asyncio_patch("gns3server.compute.docker.Docker.query", return_value=response) as mock:
+            vm = DockerVM("test", str(uuid.uuid4()), project, manager, "ubuntu:latest", extra_volumes=["/vol/1", "/vol/1"])
+            with pytest.raises(DockerError):
+                loop.run_until_complete(asyncio.ensure_future(vm.create()))
+
+def test_create_with_extra_volumes(loop, project, manager):
+
+    response = {
+        "Id": "e90e34656806",
+        "Warnings": [],
+        "Config" : {
+            "Volumes" : {
+                "/vol/1": None
+            },
+        },
+    }
+    with asyncio_patch("gns3server.compute.docker.Docker.list_images", return_value=[{"image": "ubuntu"}]) as mock_list_images:
+        with asyncio_patch("gns3server.compute.docker.Docker.query", return_value=response) as mock:
+            vm = DockerVM("test", str(uuid.uuid4()), project, manager, "ubuntu:latest", extra_volumes=["/vol/2"])
+            loop.run_until_complete(asyncio.ensure_future(vm.create()))
+            mock.assert_called_with("POST", "containers/create", data={
+                "Tty": True,
+                "OpenStdin": True,
+                "StdinOnce": False,
+                "HostConfig":
+                    {
+                        "CapAdd": ["ALL"],
+                        "Binds": [
+                            "{}:/gns3:ro".format(get_resource("compute/docker/resources")),
+                            "{}:/gns3volumes/etc/network:rw".format(os.path.join(vm.working_dir, "etc", "network")),
+                            "{}:/gns3volumes/vol/1".format(os.path.join(vm.working_dir, "vol", "1")),
+                            "{}:/gns3volumes/vol/2".format(os.path.join(vm.working_dir, "vol", "2")),
+                        ],
+                        "Privileged": True
+                    },
+                "Volumes": {},
+                "NetworkDisabled": True,
+                "Name": "test",
+                "Hostname": "test",
+                "Image": "ubuntu:latest",
+                "Env": [
+                    "container=docker",
+                    "GNS3_MAX_ETHERNET=eth0",
+                    "GNS3_VOLUMES=/etc/network:/vol/1:/vol/2"
                     ],
                 "Entrypoint": ["/gns3/init.sh"],
                 "Cmd": ["/bin/sh"]


### PR DESCRIPTION
This is a small additional feature that I have been using for a short while to allow the user to specify additional persistent volumes to be mounted for a docker container. This mitigates the need to roll a `Dockerfile` that simply adds a `VOLUME` directive to enable a persistent directory to make the image feasible to use within GNS3.

One example of this is the (elastiksearch)[https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html] docker image that is often used by logging servers and is desirable to configure within GNS3 to evaluate.

The patch add the `extra_volumes` attribute to the docker appliance, which, when the container is created is merged in with the `volumes` already specified in the image.