### PR TITLE
Don't specify the PCI bus for AHCI device

### DIFF
--- a/gns3server/compute/qemu/qemu_vm.py
+++ b/gns3server/compute/qemu/qemu_vm.py
@@ -1640,7 +1640,7 @@ class QemuVM(BaseNode):
 
             if interface == "sata":
                 # special case, sata controller doesn't exist in Qemu
-                options.extend(["-device", 'ahci,id=ahci{},bus=pci.{}'.format(disk_index, disk_index)])
+                options.extend(["-device", 'ahci,id=ahci{}'.format(disk_index)])
                 options.extend(["-drive", 'file={},if=none,id=drive-sata-disk{},index={},media=disk'.format(disk, disk_index, disk_index)])
                 options.extend(["-device", 'ide-drive,drive=drive-sata-disk{},bus=ahci{}.0,id=drive-sata-disk{}'.format(disk_index, disk_index, disk_index)])
             else:


### PR DESCRIPTION
pci.X is not always defined, let qemu handle this.

I think PCI buses only exist if PCI network adapters are defined, this
is not the case with virtio.