### PR TITLE
V2.1.21 zstdsnap - Replace zipstream with facebook zstandard compression

### DIFF
--- a/gns3server/controller/export_project.py
+++ b/gns3server/controller/export_project.py
@@ -109,6 +109,85 @@ def export_project(project, temporary_dir, include_images=False, keep_compute_id
 
     return zstream
 
+@asyncio.coroutine
+def export_project_zs(project, tmpid, temporary_dir, include_images=False, keep_compute_id=False, allow_all_nodes=False, reset_mac_addresses=False):
+    """
+    Export a project to a zstandard compressed tar file.
+
+    Some files like snapshots and packet captures are ignored.
+
+    :param temporary_dir: A temporary dir where to store intermediate data
+    :param include images: save OS images to the zip file
+    :param keep_compute_id: If false replace all compute id by local (standard behavior for .gns3project to make it portable)
+    :param allow_all_nodes: Allow all nodes type to be include in the zip even if not portable
+    :param reset_mac_addresses: Reset MAC addresses for every nodes.
+
+    :returns: simple list of files to compress
+    """
+
+    # To avoid issue with data not saved we disallow the export of a running project
+    if project.is_running():
+        raise aiohttp.web.HTTPConflict(text="Project must be stopped in order to export it")
+
+    # Make sure we save the project
+    project.dump()
+
+    filelist = {}
+
+    if not os.path.exists(project._path):
+        raise aiohttp.web.HTTPNotFound(text="Project could not be found at '{}'".format(project._path))
+
+    # First we process the .gns3 in order to be sure we don't have an error
+    for file in os.listdir(project._path):
+        if file.endswith(".gns3"):
+            yield from _patch_project_file_zs(project, tmpid, os.path.join(project._path, file), filelist, include_images, keep_compute_id, allow_all_nodes, temporary_dir, reset_mac_addresses)
+
+    # Export the local files
+    for root, dirs, files in os.walk(project._path, topdown=True, followlinks=False):
+        files = [f for f in files if _is_exportable(os.path.join(root, f))]
+        for file in files:
+            path = os.path.join(root, file)
+            # check if we can export the file
+            try:
+                open(path).close()
+            except OSError as e:
+                msg = "Could not export file '{}': {}".format(path, e)
+                log.warning(msg)
+                project.controller.notification.emit("log.warning", {"message": msg})
+                continue
+            # ignore the .gns3 file
+            if file.endswith(".gns3"):
+                continue
+            _patch_mtime(path)
+            #zstream.write(path, os.path.relpath(path, project._path), compress_type=zipfile.ZIP_DEFLATED)
+            filelist[path]=os.path.relpath(path, project._path)
+
+    # Export files from remote computes
+    downloaded_files = set()
+    for compute in project.computes:
+        if compute.id != "local":
+            compute_files = yield from compute.list_files(project)
+            for compute_file in compute_files:
+                if _is_exportable(compute_file["path"]):
+                    (fd, temp_path) = tempfile.mkstemp(dir=temporary_dir)
+                    f = open(fd, "wb", closefd=True)
+                    response = yield from compute.download_file(project, compute_file["path"])
+                    while True:
+                        try:
+                            data = yield from response.content.read(1024)
+                        except asyncio.TimeoutError:
+                            raise aiohttp.web.HTTPRequestTimeout(text="Timeout when downloading file '{}' from remote compute server {}:{}".format(compute_file["path"], compute.host, compute.port))
+                        if not data:
+                            break
+                        f.write(data)
+                    response.close()
+                    f.close()
+                    _patch_mtime(temp_path)
+                    #zstream.write(temp_path, arcname=compute_file["path"], compress_type=zipfile.ZIP_DEFLATED)
+                    filelist[temp_path]=compute_file["path"]
+                    downloaded_files.add(compute_file['path'])
+
+    return filelist
 
 def _patch_mtime(path):
     """
@@ -234,6 +313,84 @@ def _patch_project_file(project, path, zstream, include_images, keep_compute_id,
     zstream.writestr("project.gns3", json.dumps(topology).encode())
     return images
 
+@asyncio.coroutine
+def _patch_project_file_zs(project, tmpid, path, filelist, include_images, keep_compute_id, allow_all_nodes, temporary_dir, reset_mac_addresses):
+    """
+    Patch a project file (.gns3) to export a project.
+    The .gns3 file is renamed to project.gns3
+
+    :param path: path of the .gns3 file
+    """
+
+    # image files that we need to include in the exported archive
+    images = []
+
+    try:
+        with open(path) as f:
+            topology = json.load(f)
+    except (OSError, ValueError) as e:
+        raise aiohttp.web.HTTPConflict(text="Project file '{}' cannot be read: {}".format(path, e))
+
+    if "topology" in topology:
+        if "nodes" in topology["topology"]:
+            for node in topology["topology"]["nodes"]:
+                compute_id = node.get('compute_id', 'local')
+
+                if node["node_type"] == "virtualbox" and node.get("properties", {}).get("linked_clone"):
+                    raise aiohttp.web.HTTPConflict(text="Projects with a linked {} clone node cannot not be exported. Please use Qemu instead.".format(node["node_type"]))
+                if not allow_all_nodes and node["node_type"] in ["virtualbox", "vmware", "cloud"]:
+                    raise aiohttp.web.HTTPConflict(text="Projects with a {} node cannot be exported".format(node["node_type"]))
+
+                if not keep_compute_id:
+                    node["compute_id"] = "local"  # To make project portable all node by default run on local
+
+                if "properties" in node and node["node_type"] != "docker":
+                    for prop, value in node["properties"].items():
+
+                        # reset the MAC address
+                        if reset_mac_addresses and prop in ("mac_addr", "mac_address"):
+                            node["properties"][prop] = None
+
+                        if node["node_type"] == "iou":
+                            if not prop == "path":
+                                continue
+                        elif not prop.endswith("image"):
+                            continue
+                        if value is None or value.strip() == '':
+                            continue
+
+                        if not keep_compute_id:  # If we keep the original compute we can keep the image path
+                            node["properties"][prop] = os.path.basename(value)
+
+                        if include_images is True:
+                            images.append({
+                                'compute_id': compute_id,
+                                'image': value,
+                                'image_type': node['node_type']
+                            })
+
+        if not keep_compute_id:
+            topology["topology"]["computes"] = []  # Strip compute information because could contain secret info like password
+
+    local_images = set([i['image'] for i in images if i['compute_id'] == 'local'])
+
+    for image in local_images:
+        _export_local_image_zs(image, filelist)
+
+    remote_images = set([
+        (i['compute_id'], i['image_type'], i['image'])
+        for i in images if i['compute_id'] != 'local'])
+
+    for compute_id, image_type, image in remote_images:
+        yield from _export_remote_images_zs(project, compute_id, image_type, image, zstream, temporary_dir)
+
+    #zstream.writestr("project.gns3", json.dumps(topology).encode())
+    tmppath = "/tmp/project_" + tmpid + ".gns3"
+    with open(tmppath,'wb') as projectfile:
+        projectfile.write(json.dumps(topology).encode())
+    filelist[tmppath]="project.gns3"
+    return images
+
 def _export_local_image(image, zstream):
     """
     Exports a local image to the zip file.
@@ -262,6 +419,33 @@ def _export_local_image(image, zstream):
             zstream.write(path, arcname)
             return
 
+def _export_local_image_zs(image, filelist):
+    """
+    Exports a local image to the zstandard file
+
+    :param image: image path
+    :param filelist: path list to add to tar later
+    """
+
+    from ..compute import MODULES
+    for module in MODULES:
+        try:
+            images_directory = module.instance().get_images_directory()
+        except NotImplementedError:
+            # Some modules don't have images
+            continue
+
+        directory = os.path.split(images_directory)[-1:][0]
+        if os.path.exists(image):
+            path = image
+        else:
+            path = os.path.join(images_directory, image)
+
+        if os.path.exists(path):
+            arcname = os.path.join("images", directory, os.path.basename(image))
+            _patch_mtime(path)
+            filelist[path]=arcname
+            return
 
 @asyncio.coroutine
 def _export_remote_images(project, compute_id, image_type, image, project_zipfile, temporary_dir):
@@ -296,3 +480,37 @@ def _export_remote_images(project, compute_id, image_type, image, project_zipfil
     arcname = os.path.join("images", image_type, image)
     log.info("Saved {}".format(arcname))
     project_zipfile.write(temp_path, arcname=arcname, compress_type=zipfile.ZIP_DEFLATED)
+
+@asyncio.coroutine
+def _export_remote_images_zs(project, compute_id, image_type, image, project_filelist, temporary_dir):
+    """
+    Export specific image from remote compute.
+    """
+
+    log.info("Downloading image '{}' from compute server '{}'".format(image, compute_id))
+
+    try:
+        compute = [compute for compute in project.computes if compute.id == compute_id][0]
+    except IndexError:
+        raise aiohttp.web.HTTPConflict(text="Cannot export image from '{}' compute. Compute doesn't exist.".format(compute_id))
+
+    (fd, temp_path) = tempfile.mkstemp(dir=temporary_dir)
+    f = open(fd, "wb", closefd=True)
+    response = yield from compute.download_image(image_type, image)
+
+    if response.status != 200:
+        raise aiohttp.web.HTTPConflict(text="Cannot export image from '{}' compute. Compute returned status code {}.".format(compute_id, response.status))
+
+    while True:
+        try:
+            data = yield from response.content.read(1024)
+        except asyncio.TimeoutError:
+            raise aiohttp.web.HTTPRequestTimeout(text="Timeout when downloading image '{}' from remote compute server {}:{}".format(image, compute.host, compute.port))
+        if not data:
+            break
+        f.write(data)
+    response.close()
+    f.close()
+    arcname = os.path.join("images", image_type, image)
+    log.info("Saved {}".format(arcname))
+    project_filelist[temp_path]=arcname

--- a/gns3server/controller/project.py
+++ b/gns3server/controller/project.py
@@ -160,7 +160,7 @@ class Project:
         snapshot_dir = os.path.join(self.path, "snapshots")
         if os.path.exists(snapshot_dir):
             for snap in os.listdir(snapshot_dir):
-                if snap.endswith(".gns3project"):
+                if snap.endswith(".gns3project") or snap.endswith(".genens3"):
                     snapshot = Snapshot(self, filename=snap)
                     self._snapshots[snapshot.id] = snapshot
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ psutil>=3.0.0
 zipstream>=1.1.4
 prompt-toolkit==1.0.15
 async-timeout<3.0.0 # pyup: ignore; 3.0 drops support for python 3.4
-python-zstandard>=0.12.0
+zstandard>=0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ psutil>=3.0.0
 zipstream>=1.1.4
 prompt-toolkit==1.0.15
 async-timeout<3.0.0 # pyup: ignore; 3.0 drops support for python 3.4
+python-zstandard>=0.12.0

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ dependencies = open("requirements.txt", "r").read().splitlines()
 setup(
     name="gns3-server",
     version=__import__("gns3server").__version__,
-    url="http://github.com/GNS3/gns3-server",
+    url="https://github.com/gleyfer/gns3-server/",
     license="GNU General Public License v3 (GPLv3)",
     tests_require=["pytest", "pytest-capturelog"],
     cmdclass={"test": PyTest},


### PR DESCRIPTION
I did not see https://github.com/GNS3/gns3-server/pull/1537 prior to completing this, but I wanted to at least share my work and see if it can be incorporated at some point.

I have added functions in the snapshot/project export/project import/project.py to utilize the python-zstandard library and its substantially faster multi-threaded encoder. The encoder achieves much better compression ratios with MUCH faster throughput. It also offers much more configuration to choose between speed or file size.

Rather than using a zipstream, I used a regular python dict to store the file paths/arcnames and pushed them into a tarfile which is feeding into a zstandard streaming compressor using their streaming API.

You can see the performance differences here: https://github.com/gleyfer/gns3-server/blob/v2.1.21-zstdsnap/README.rst

Snapshotting one of my source project folder at 154GB was taking 2+ hours, longer than the default TCP socket timeout on my server and it would error out on the GUI side. The produced snapshot was around 69GB . With the zstandard at compression level 11, long range matching enabled and a 2GB window, I am able to compress to a 38GB file from the same source project within 30 minutes.

The default compression settings in my commits are very aggressive and assume a powerful CPU/a lot of memory but produce a much better compression ratio at 4x+ the speed of zipstream. With less complicated compression strategies and faster backing storage it is possible to achieve much higher throughputs with much lower memory utilization.

Currently, I only have this set to be done for snapshots. For regular project export/import I use the normal zipstream. This is to maintain compatibility with normal GNS3 versions. It will also list and import the old snapshots as well using the existing code.

There are some obvious things I haven't gotten to yet (and many more I'm sure I am too much of a novice to know):

1. My dict isn't sorted/project.gns3 isn't at the very beginning of the snapshot file so I'm not verifying validity first then extracting later. It is the opposite, where I run an extractall and then check the project.gns3. This can be easily fixed.
2. I based all of my commits off 2.1.21 as this was the version I had installed and could test on.
3. This solution isn't currently portable. It requires both ends to be patched to import projects between different gns3server instances. Perhaps some gui option could be added to choose type. For now I just have it using the traditional zipstream for export/import.
4. No way to control the compression level from the GUI, needs to be manually adjusted in the python file at the moment.