### PR TITLE
Server statistics implementation. Ref #1682

### DIFF
--- a/gns3server/handlers/api/controller/server_handler.py
+++ b/gns3server/handlers/api/controller/server_handler.py
@@ -130,6 +130,24 @@ class ServerHandler:
         response.json(iou_license)
         response.set_status(201)
 
+    @Route.get(
+        r"/statistics",
+        description="Retrieve server statistics",
+        status_codes={
+            200: "Statistics information returned",
+            409: "Conflict"
+        })
+    async def statistics(request, response):
+
+        compute_statistics = {}
+        for compute in list(Controller.instance().computes.values()):
+            try:
+                r = await compute.get("/statistics")
+                compute_statistics[compute.name] = r.json
+            except HTTPConflict as e:
+                log.error("Could not retrieve statistics on compute {}: {}".format(compute.name, e.text))
+        response.json(compute_statistics)
+
     @Route.post(
         r"/debug",
         description="Dump debug information to disk (debug directory in config directory). Work only for local server",

--- a/gns3server/handlers/api/controller/server_handler.py
+++ b/gns3server/handlers/api/controller/server_handler.py
@@ -139,11 +139,11 @@ class ServerHandler:
         })
     async def statistics(request, response):
 
-        compute_statistics = {}
+        compute_statistics = []
         for compute in list(Controller.instance().computes.values()):
             try:
                 r = await compute.get("/statistics")
-                compute_statistics[compute.name] = r.json
+                compute_statistics.append({"compute_id": compute.id, "compute_name": compute.name, "statistics": r.json})
             except HTTPConflict as e:
                 log.error("Could not retrieve statistics on compute {}: {}".format(compute.name, e.text))
         response.json(compute_statistics)

--- a/gns3server/schemas/server_statistics.py
+++ b/gns3server/schemas/server_statistics.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015 GNS3 Technologies Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+SERVER_STATISTICS_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "required": ["memory_total",
+                 "memory_free",
+                 "memory_used",
+                 "swap_total",
+                 "swap_free",
+                 "swap_used",
+                 "cpu_usage_percent",
+                 "memory_usage_percent",
+                 "swap_usage_percent",
+                 "disk_usage_percent",
+                 "load_average_percent"],
+    "additionalProperties": False,
+    "properties": {
+        "memory_total": {
+            "description": "Total physical memory (exclusive swap) in bytes",
+            "type": "integer",
+        },
+        "memory_free": {
+            "description": "Free memory in bytes",
+            "type": "integer",
+        },
+        "memory_used": {
+            "description": "Memory used in bytes",
+            "type": "integer",
+        },
+        "swap_total": {
+            "description": "Total swap memory in bytes",
+            "type": "integer",
+        },
+        "swap_free": {
+            "description": "Free swap memory in bytes",
+            "type": "integer",
+        },
+        "swap_used": {
+            "description": "Swap memory used in bytes",
+            "type": "integer",
+        },
+        "cpu_usage_percent": {
+            "description": "CPU usage in percent",
+            "type": "integer",
+        },
+        "memory_usage_percent": {
+            "description": "Memory usage in percent",
+            "type": "integer",
+        },
+        "swap_usage_percent": {
+            "description": "Swap usage in percent",
+            "type": "integer",
+        },
+        "disk_usage_percent": {
+            "description": "Disk usage in percent",
+            "type": "integer",
+        },
+        "load_average_percent": {
+            "description": "Average system load over the last 1, 5 and 15 minutes",
+            "type": "array",
+            "items": [{"type": "integer"}],
+            "minItems": 3,
+            "maxItems": 3
+        },
+    }
+}

--- a/tests/handlers/api/compute/test_server.py
+++ b/tests/handlers/api/compute/test_server.py
@@ -37,3 +37,8 @@ def test_version_output(http_compute):
 def test_debug_output(http_compute):
     response = http_compute.get('/debug')
     assert response.status == 200
+
+
+def test_statistics_output(http_compute):
+    response = http_compute.get('/statistics')
+    assert response.status == 200

--- a/tests/handlers/api/controller/test_server.py
+++ b/tests/handlers/api/controller/test_server.py
@@ -70,3 +70,8 @@ def test_debug_non_local(http_controller, config, tmpdir):
     config.set("Server", "local", False)
     response = http_controller.post('/debug')
     assert response.status == 403
+
+
+def test_statistics_output(http_controller):
+    response = http_controller.get('/statistics')
+    assert response.status == 200


### PR DESCRIPTION
There are 2 endpoints.

On compute level (private API), statistics about CPU, memory, swap and disk are returned

GET `http://localhost:3080/v2/compute/statistics`

```
{
    "cpu_usage_percent": 20,
    "disk_usage_percent": 95,
    "load_average_percent": [
        30,
        23,
        21
    ],
    "memory_free": 6105800704,
    "memory_total": 16453206016,
    "memory_usage_percent": 62,
    "memory_used": 10347405312,
    "swap_free": 12032184320,
    "swap_total": 17179865088,
    "swap_usage_percent": 30,
    "swap_used": 5147680768
}
```

On controller level (public API), an array of computes is returned. Each entry has the compute ID and compute name along with the statistics specific to that compute.

GET `http://localhost:3080/v2/statistics`

```
[
    {
        "compute_id": "local",
        "compute_name": "Coruscant",
        "statistics": {
            "cpu_usage_percent": 23,
            "disk_usage_percent": 95,
            "load_average_percent": [
                31,
                22,
                21
            ],
            "memory_free": 6068559872,
            "memory_total": 16453206016,
            "memory_usage_percent": 63,
            "memory_used": 10384646144,
            "swap_free": 12031397888,
            "swap_total": 17179865088,
            "swap_usage_percent": 30,
            "swap_used": 5148467200
        }
    },
    {
        "compute_id": "remote",
        "compute_name": "Tatooine",
        "statistics": {
            "cpu_usage_percent": 76,
            "disk_usage_percent": 50,
            "load_average_percent": [
                10,
                5,
                65
            ],
            "memory_free": 6068559872,
            "memory_total": 16453206016,
            "memory_usage_percent": 33,
            "memory_used": 10384646144,
            "swap_free": 12031397888,
            "swap_total": 17179865088,
            "swap_usage_percent": 20,
            "swap_used": 5148467200
        }
    }
]
```