### PR TITLE
Recent Qemu versions support. Ref #1699

### DIFF
--- a/gns3server/compute/qemu/qemu_vm.py
+++ b/gns3server/compute/qemu/qemu_vm.py
@@ -1723,10 +1723,13 @@ class QemuVM(BaseNode):
 
         patched_qemu = False
         if self._legacy_networking:
-            version = await self.manager.get_qemu_version(self.qemu_path)
-            if version and parse_version(version) < parse_version("1.1.0"):
-                # this is a patched Qemu if version is below 1.1.0
-                patched_qemu = True
+            qemu_version = await self.manager.get_qemu_version(self.qemu_path)
+            if qemu_version:
+                if parse_version(qemu_version) >= parse_version("2.9.0"):
+                    raise QemuError("Qemu version 2.9.0 and later doesn't support legacy networking mode")
+                if parse_version(qemu_version) < parse_version("1.1.0"):
+                    # this is a patched Qemu if version is below 1.1.0
+                    patched_qemu = True
 
         # Each 32 PCI device we need to add a PCI bridge with max 9 bridges
         pci_devices = 4 + len(self._ethernet_adapters)  # 4 PCI devices are use by default by qemu

--- a/gns3server/compute/qemu/qemu_vm.py
+++ b/gns3server/compute/qemu/qemu_vm.py
@@ -1645,9 +1645,18 @@ class QemuVM(BaseNode):
             if interface == "sata":
                 # special case, sata controller doesn't exist in Qemu
                 options.extend(["-device", 'ahci,id=ahci{}'.format(disk_index)])
-                options.extend(["-drive", 'file={},if=none,id=drive{},index={},media=disk'.format(disk, disk_index, disk_index)])
+                options.extend(["-drive", 'file={},if=none,id=drive{},index={},media=disk,format=raw'.format(disk, disk_index, disk_index)])
                 options.extend(["-device", 'ide-drive,drive=drive{},bus=ahci{}.0,id=drive{}'.format(disk_index, disk_index, disk_index)])
-
+            elif interface == "nvme":
+                options.extend(["-drive", 'file={},if=none,id=drive{},index={},media=disk,format=raw'.format(disk, disk_index, disk_index)])
+                options.extend(["-device", 'nvme,drive=drive{},serial={}'.format(disk_index, disk_index)])
+            elif interface == "scsi":
+                options.extend(["-device", 'virtio-scsi-pci,id=scsi{}'.format(disk_index)])
+                options.extend(["-drive", 'file={},if=none,id=drive{},index={},media=disk,format=raw'.format(disk, disk_index, disk_index)])
+                options.extend(["-device", 'scsi-hd,drive=drive{}'.format(disk_index)])
+            #elif interface == "sd":
+            #    options.extend(["-drive", 'file={},id=drive{},index={},format=raw'.format(disk, disk_index, disk_index)])
+            #    options.extend(["-device", 'sd-card,drive=drive{},id=drive{}'.format(disk_index, disk_index, disk_index)])
             else:
                 options.extend(["-drive", 'file={},if={},index={},media=disk,id=drive{}'.format(disk, interface, disk_index, disk_index)])
 

--- a/gns3server/schemas/qemu_template.py
+++ b/gns3server/schemas/qemu_template.py
@@ -115,7 +115,7 @@ QEMU_TEMPLATE_PROPERTIES = {
     },
     "hda_disk_interface": {
         "description": "QEMU hda interface",
-        "enum": ["ide", "sata", "scsi", "sd", "mtd", "floppy", "pflash", "virtio", "none"],
+        "enum": ["ide", "sata", "nvme", "scsi", "sd", "mtd", "floppy", "pflash", "virtio", "none"],
         "default": "ide"
     },
     "hdb_disk_image": {
@@ -125,7 +125,7 @@ QEMU_TEMPLATE_PROPERTIES = {
     },
     "hdb_disk_interface": {
         "description": "QEMU hdb interface",
-        "enum": ["ide", "sata", "scsi", "sd", "mtd", "floppy", "pflash", "virtio", "none"],
+        "enum": ["ide", "sata", "nvme", "scsi", "sd", "mtd", "floppy", "pflash", "virtio", "none"],
         "default": "ide"
     },
     "hdc_disk_image": {
@@ -135,7 +135,7 @@ QEMU_TEMPLATE_PROPERTIES = {
     },
     "hdc_disk_interface": {
         "description": "QEMU hdc interface",
-        "enum": ["ide", "sata", "scsi", "sd", "mtd", "floppy", "pflash", "virtio", "none"],
+        "enum": ["ide", "sata", "nvme", "scsi", "sd", "mtd", "floppy", "pflash", "virtio", "none"],
         "default": "ide"
     },
     "hdd_disk_image": {
@@ -145,7 +145,7 @@ QEMU_TEMPLATE_PROPERTIES = {
     },
     "hdd_disk_interface": {
         "description": "QEMU hdd interface",
-        "enum": ["ide", "sata", "scsi", "sd", "mtd", "floppy", "pflash", "virtio", "none"],
+        "enum": ["ide", "sata", "nvme", "scsi", "sd", "mtd", "floppy", "pflash", "virtio", "none"],
         "default": "ide"
     },
     "cdrom_image": {

--- a/gns3server/schemas/qemu_template.py
+++ b/gns3server/schemas/qemu_template.py
@@ -64,9 +64,9 @@ QEMU_TEMPLATE_PROPERTIES = {
     "adapter_type": {
         "description": "QEMU adapter type",
         "type": "string",
-        "enum": ["e1000", "i82550", "i82551", "i82557a", "i82557b", "i82557c", "i82558a","i82558b", "i82559a",
-                 "i82559b", "i82559c", "i82559er", "i82562", "i82801", "ne2k_pci", "pcnet", "rtl8139", "virtio",
-                 "virtio-net-pci", "vmxnet3"],
+        "enum": ["e1000", "e1000-82544gc", "e1000-82545em", "e1000e", "i82550", "i82551", "i82557a", "i82557b", "i82557c", "i82558a",
+                 "i82558b", "i82559a", "i82559b", "i82559c", "i82559er", "i82562", "i82801", "ne2k_pci", "pcnet", "rocker", "rtl8139",
+                 "virtio", "virtio-net-pci", "vmxnet3"],
         "default": "e1000"
     },
     "mac_address": {


### PR DESCRIPTION
* Add "e1000-82544gc", "e1000-82545em", "e1000e" and "rocker" NIC models.
* Prevent running Qemu >= 2.9.0 with legacy mode.
* Fix scsi disk interface.
* Add nvme disk interface.