### PR TITLE
Option to reset MAC addresses when exporting or duplicating a project

### DIFF
--- a/gns3server/controller/project.py
+++ b/gns3server/controller/project.py
@@ -999,7 +999,7 @@ class Project:
         while self._loading:
             await asyncio.sleep(0.5)
 
-    async def duplicate(self, name=None, location=None):
+    async def duplicate(self, name=None, location=None, reset_mac_addresses=True):
         """
         Duplicate a project
 
@@ -1009,6 +1009,7 @@ class Project:
 
         :param name: Name of the new project. A new one will be generated in case of conflicts
         :param location: Parent directory of the new project
+        :param reset_mac_addresses: Reset MAC addresses for the new project
         """
         # If the project was not open we open it temporary
         previous_status = self._status
@@ -1022,7 +1023,7 @@ class Project:
             with tempfile.TemporaryDirectory() as tmpdir:
                 # Do not compress the exported project when duplicating
                 with aiozipstream.ZipFile(compression=zipfile.ZIP_STORED) as zstream:
-                    await export_project(zstream, self, tmpdir, keep_compute_id=True, allow_all_nodes=True, reset_mac_addresses=True)
+                    await export_project(zstream, self, tmpdir, keep_compute_id=True, allow_all_nodes=True, reset_mac_addresses=reset_mac_addresses)
 
                     # export the project to a temporary location
                     project_path = os.path.join(tmpdir, "project.gns3p")

--- a/gns3server/schemas/project.py
+++ b/gns3server/schemas/project.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import copy
+
 SUPPLIER_OBJECT_SCHEMA = {
     "type": ["object", "null"],
     "description": "Supplier of the project",
@@ -119,6 +121,13 @@ PROJECT_CREATE_SCHEMA = {
     "additionalProperties": False,
     "required": ["name"]
 }
+
+# Create a project duplicate schema based on create schema and add "reset_mac_addresses" properties
+PROJECT_DUPLICATE_SCHEMA = copy.deepcopy(PROJECT_CREATE_SCHEMA)
+PROJECT_DUPLICATE_SCHEMA["description"] = "Request validation to duplicate a Project instance"
+PROJECT_DUPLICATE_SCHEMA["properties"].update({"reset_mac_addresses": {"type": "boolean",
+                                                                       "description": "Reset MAC addresses for this project"
+                                                                      }})
 
 PROJECT_UPDATE_SCHEMA = {
     "$schema": "http://json-schema.org/draft-04/schema#",


### PR DESCRIPTION
Added a option to reset or not all MAC addresses when exporting or duplicating a project. This fixes #1762