### PR TITLE
One GNS3 Server | Multiples GNS3 clients (client Isolation) 

### DIFF
--- a/gns3server/version.py
+++ b/gns3server/version.py
@@ -23,8 +23,8 @@
 # or negative for a release candidate or beta (after the base version
 # number has been incremented)
 
-__version__ = "2.2.13"
-__version_info__ = (2, 2, 13, 0)
+__version__ = "2.2.14dev1"
+__version_info__ = (2, 2, 14, 99)
 
 if "dev" in __version__:
     try:


### PR DESCRIPTION
One GNS3 Server | Multiples GNS3 clients (client Isolation)
There is no user isolation, all users can view all projects and modify them.
Any plans to work  Isolating GNS3 clients  Connecting to the GNS3 Server and isolates Projects, settings, and avoid being modified by other clients .

