### PR TITLE
fixed limit of 512 ious being across all computes, instead of per-com…

### DIFF
--- a/gns3server/utils/application_id.py
+++ b/gns3server/utils/application_id.py
@@ -38,7 +38,7 @@ def get_next_application_id(projects, compute):
         if project.status == "opened" and compute in project.computes:
             nodes.extend(list(project.nodes.values()))
 
-    used = set([n.properties["application_id"] for n in nodes if n.node_type == "iou" and n.compute == compute])
+    used = set([n.properties["application_id"] for n in nodes if (n.node_type == "iou" and n.compute == compute)])
     pool = set(range(1, 512))
     try:
         return (pool - used).pop()

--- a/gns3server/utils/application_id.py
+++ b/gns3server/utils/application_id.py
@@ -38,7 +38,7 @@ def get_next_application_id(projects, compute):
         if project.status == "opened" and compute in project.computes:
             nodes.extend(list(project.nodes.values()))
 
-    used = set([n.properties["application_id"] for n in nodes if n.node_type == "iou"])
+    used = set([n.properties["application_id"] for n in nodes if n.node_type == "iou" and n.compute == compute])
     pool = set(range(1, 512))
     try:
         return (pool - used).pop()


### PR DESCRIPTION
Although the comment in this section says that there should be a limit of 512 ious **per compute**, there is currently a single global limit of 512 ioud for all computes together.
This is a simple fix for that, making the functionality work as intended - 512 ious per compute. 