### PR TITLE
Docker enhancement to grant the user the ability to modify the contai…

### DIFF
--- a/gns3server/handlers/api/compute/docker_handler.py
+++ b/gns3server/handlers/api/compute/docker_handler.py
@@ -62,7 +62,8 @@ class DockerHandler:
                                                           console_http_path=request.json.get("console_http_path", "/"),
                                                           aux=request.json.get("aux"),
                                                           extra_hosts=request.json.get("extra_hosts"),
-                                                          extra_volumes=request.json.get("extra_volumes"))
+                                                          extra_volumes=request.json.get("extra_volumes"),
+                                                          extra_parameters=request.json.get("extra_parameters"))
         for name, value in request.json.items():
             if name != "node_id":
                 if hasattr(container, name) and getattr(container, name) != value:
@@ -317,7 +318,7 @@ class DockerHandler:
         props = [
             "name", "console", "aux", "console_type", "console_resolution",
             "console_http_port", "console_http_path", "start_command",
-            "environment", "adapters", "extra_hosts", "extra_volumes"
+            "environment", "adapters", "extra_hosts", "extra_volumes", "extra_parameters"
         ]
 
         changed = False

--- a/gns3server/schemas/docker.py
+++ b/gns3server/schemas/docker.py
@@ -103,6 +103,11 @@ DOCKER_CREATE_SCHEMA = {
                 "type": "string"
             }
         },
+        "extra_parameters": {
+            "description": "Docker extra create parameters (used in docker create)",
+            "type": ["string", "null"],
+            "minLength": 0,
+        },
         "container_id": {
             "description": "Docker container ID Read only",
             "type": "string",
@@ -213,6 +218,11 @@ DOCKER_OBJECT_SCHEMA = {
             "items": {
                 "type": "string",
             }
+        },
+        "extra_parameters": {
+            "description": "Docker extra parameters ()",
+            "type": ["string", "null"],
+            "minLength": 0,
         },
         "node_directory": {
             "description": "Path to the node working directory  Read only",

--- a/gns3server/schemas/docker_template.py
+++ b/gns3server/schemas/docker_template.py
@@ -87,6 +87,11 @@ DOCKER_TEMPLATE_PROPERTIES = {
         "type": "array",
         "default": []
     },
+    "extra_parameters": {
+        "description": "Docker extra create parameters (used in docker create)",
+        "type": "string",
+        "default": ""
+    },
     "custom_adapters": CUSTOM_ADAPTERS_ARRAY_SCHEMA
 }
 

--- a/tests/handlers/api/compute/test_docker.py
+++ b/tests/handlers/api/compute/test_docker.py
@@ -37,7 +37,8 @@ def base_params():
         "environment": "YES=1\nNO=0",
         "console_type": "telnet",
         "console_resolution": "1280x1024",
-        "extra_hosts": "test:127.0.0.1"
+        "extra_hosts": "test:127.0.0.1",
+        "extra_parameters": """{"StopSignal": "SIGRTMIN+3"}"""
     }
     return params
 
@@ -78,6 +79,7 @@ async def test_docker_create(compute_api, compute_project, base_params):
     assert response.json["environment"] == "YES=1\nNO=0"
     assert response.json["console_resolution"] == "1280x1024"
     assert response.json["extra_hosts"] == "test:127.0.0.1"
+    assert response.json["extra_parameters"] == """{"StopSignal": "SIGRTMIN+3"}"""
 
 
 async def test_docker_start(compute_api, vm):
@@ -174,7 +176,8 @@ async def test_docker_update(compute_api, vm, free_console_port):
         "console": free_console_port,
         "start_command": "yes",
         "environment": "GNS3=1\nGNS4=0",
-        "extra_hosts": "test:127.0.0.1"
+        "extra_hosts": "test:127.0.0.1",
+        "extra_parameters": """{"StopSignal": "SIGRTMIN+3"}"""
     }
 
     with asyncio_patch("gns3server.compute.docker.docker_vm.DockerVM.update") as mock:
@@ -186,6 +189,7 @@ async def test_docker_update(compute_api, vm, free_console_port):
     assert response.json["start_command"] == "yes"
     assert response.json["environment"] == "GNS3=1\nGNS4=0"
     assert response.json["extra_hosts"] == "test:127.0.0.1"
+    assert response.json["extra_parameters"] == """{"StopSignal": "SIGRTMIN+3"}"""
 
 
 async def test_docker_start_capture(compute_api, vm):


### PR DESCRIPTION
Docker - pass custom parameters to container create

Why:

Several use cases require the need to alter the docker container create
  1. Running systemd containers require special binds plus a custom termination signal
  2. Running systemd in sysbox containers require custom runtime as well as Privileged=false
  3. Many other use cases exist and will only grow as Docker becomes even more commonplace

This change addresses the need by:

 1. Adding a custom textedit to the Docker container Advanced tab
 2. Adding the custom fields to the GNS3 schemas and objects
 3. Adding logic to the Docker create function to merge the custom parameters

NB: This change is depenant on modifications to both gns3-gui and gns3-server