### PR TITLE
Set py-cpuinfo to 8.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ sentry-sdk==1.0.0
 psutil==5.8.0
 async-timeout==3.0.1
 distro==1.5.0
-py-cpuinfo==7.0.0
+py-cpuinfo==8.0.0


### PR DESCRIPTION
`py-cpuinfo` was released a while back. According to the [Changelog](https://github.com/workhorsy/py-cpuinfo/blob/master/ChangeLog) it looks like a bugfix release.

The requirement are pinned and this causes build failures for distribution packages if the don't match the latest available release.