### PR TITLE
Fix VMware VM support on macOS BigSur

### DIFF
--- a/gns3server/compute/builtin/nodes/cloud.py
+++ b/gns3server/compute/builtin/nodes/cloud.py
@@ -362,12 +362,12 @@ class Cloud(BaseNode):
         """
 
         # Wireless adapters are not well supported by the libpcap on OSX
-        if (await self._is_wifi_adapter_osx(port_info["interface"])):
+        if await self._is_wifi_adapter_osx(port_info["interface"]):
             raise NodeError("Connecting to a Wireless adapter is not supported on Mac OS")
         if port_info["interface"].startswith("vmnet"):
             # Use a special NIO to connect to VMware vmnet interfaces on OSX (libpcap doesn't support them)
             await self._ubridge_send('bridge add_nio_fusion_vmnet {name} "{interface}"'.format(name=bridge_name,
-                                                                                                    interface=port_info["interface"]))
+                                                                                               interface=port_info["interface"]))
             return
         if not gns3server.utils.interfaces.has_netmask(port_info["interface"]):
             raise NodeError("Interface {} has no netmask, interface down?".format(port_info["interface"]))


### PR DESCRIPTION
VMware Fusion creates "bridge" interfaces (bridge100, bridge101 etc.) instead of the usual vmnet ones on macOS BigSur. Also, these interfaces are only created once a VM starts. This PR implements a way to find those bridge interfaces to be used in uBridge.

Should fix #1912 and https://github.com/GNS3/gns3-gui/issues/3106