### PR TITLE
change code in vmware_vm.py

### DIFF
--- a/gns3server/version.py
+++ b/gns3server/version.py
@@ -23,8 +23,8 @@
 # or negative for a release candidate or beta (after the base version
 # number has been incremented)
 
-__version__ = "2.2.22"
-__version_info__ = (2, 2, 22, 0)
+__version__ = "2.2.23dev1"
+__version_info__ = (2, 2, 23, 99)
 
 if "dev" in __version__:
     try:


### PR DESCRIPTION
reading through the code in the file vmware_vm.py and playing around with gns3 v2.2.22 where i came across a minor error.

file: vmware_vm.py
method: async def _add_ubridge_connection(self, nio, adapter_number):
line: 348
current code text: raise VMwareError(f"fCould not find bridge interface linked with {vmnet_interface}")
proposed code text: raise VMwareError(f"Could not find bridge interface linked with {vmnet_interface}")

basically, remove "f" in front of "Could"