### PR TITLE
Support cloning of encrypted qcow2 base image files

### DIFF
--- a/gns3server/compute/qemu/utils/qcow2.py
+++ b/gns3server/compute/qemu/utils/qcow2.py
@@ -58,11 +58,12 @@ class Qcow2:
         #     uint64_t snapshots_offset;
         # } QCowHeader;
 
-        struct_format = ">IIQi"
+        struct_format = ">IIQiiQi"
         with open(self._path, 'rb') as f:
             content = f.read(struct.calcsize(struct_format))
             try:
-                self.magic, self.version, self.backing_file_offset, self.backing_file_size = struct.unpack_from(struct_format, content)
+                (self.magic, self.version, self.backing_file_offset, self.backing_file_size,
+                    self.cluster_bits, self.size, self.crypt_method) = struct.unpack_from(struct_format, content)
 
             except struct.error:
                 raise Qcow2Error("Invalid file header for {}".format(self._path))
@@ -103,3 +104,15 @@ class Qcow2:
         if retcode != 0:
             raise Qcow2Error("Could not rebase the image")
         self._reload()
+
+    async def validate(self, qemu_img):
+        """
+        Run qemu-img info to validate the file and its backing images
+
+        :param qemu_img: Path to the qemu-img binary
+        """
+        command = [qemu_img, "info", "--backing-chain", self._path]
+        process = await asyncio.create_subprocess_exec(*command)
+        retcode = await process.wait()
+        if retcode != 0:
+            raise Qcow2Error("Could not validate the image")


### PR DESCRIPTION
This is a minimal changeset to address #1921.

This patch parses the json output from `qemu_img info`, both as a way of validating the image without calling `rebase`, and to obtain the base image virtual-size and encryption flag.

It uses the existing `_qemu_img_exec`, which mixes stdout and stderr together and writes them to `_qemu_img_stdout_file`, and is then read back by `read_qemu_img_stdout()`.  It works because the stderr output happens to be empty when there's valid info output on stdout.

Arguably it would be cleaner to separate stdout and stderr, either to two separate files, or a stderr file and RAM, or just read them both into RAM: e.g.

```
process = await asyncio.create_subprocess_exec(*command, stdout=asyncio.subprocess.PIPE,
                        stderr=asyncio.subprocess.PIPE, cwd=self.working_dir)
(stdout_data, stderr_data) = await process.communicate()
log.info("{} returned with {}".format(self._get_qemu_img(), process.returncode))
return (process.returncode, stdout_data, stderr_data)
```

But that would be a more invasive change (and I'm not sure if the output file is wanted on disk for other purposes)