### PR TITLE
setup.py: prevent installing tests directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
             "gns3loopback = gns3server.utils.windows_loopback:main"
         ]
     },
-    packages=find_packages(".", exclude=["docs", "tests"]),
+    packages=find_packages(".", exclude=["docs", "tests*"]),
     include_package_data=True,
     zip_safe=False,
     platforms="any",


### PR DESCRIPTION
Hi,

I'm trying to get tests working for the gentoo ebuild, but have a minor issue with the installation.
For some reason the package tries to install the tests directory which it shouldn't do and which is why it got removed previously.

Now I was looking into it and it seems that, as soon as the tests directory has a `__init__.py` file, it wouldn't be excluded anymore by `find_packages` (even though it's clearly excluded there). This is also the reason why for example `gns3-gui` doesn't has this problem.

The proposed change fixes this issue.
