### PR TITLE
Fix binary websocket access to the console

### DIFF
--- a/gns3server/compute/base_node.py
+++ b/gns3server/compute/base_node.py
@@ -430,7 +430,7 @@ class BaseNode:
                     telnet_writer.write(msg.data.encode())
                     await telnet_writer.drain()
                 elif msg.type == aiohttp.WSMsgType.BINARY:
-                    await telnet_writer.write(msg.data)
+                    telnet_writer.write(msg.data)
                     await telnet_writer.drain()
                 elif msg.type == aiohttp.WSMsgType.ERROR:
                     log.debug("Websocket connection closed with exception {}".format(ws.exception()))


### PR DESCRIPTION
telnet_writer.write is not an async method - drain() is.
Remove async keyword so the call is the same as for the text websocket.

Using great [websocat](https://github.com/vi/websocat) socat, I try to access to console of apliances running inside GNS3.

```
$ websocat_amd64-linux -b \
    tcp-listen:127.0.0.1:5000 \
    ws://127.0.0.1:3080/v2/projects/0ac64a65-7f44-491e-b1b1-426c8a23129f/nodes/0af7b275-ed6d-4dc3-a36d-8b86a9686bfb/console/ws
```
This exposes telnet server of the remote console on  localhost port 5000.

I don't know (yet) why it doesn't work in textual mode, trying binary mode (above command, -b argument) revealed a bug that this pull request fixes. 

With this fix, it is now possible to connect to remote console using telnet command from the CLI.

