### PR TITLE
List disk usage for all mount points

### DIFF
--- a/conf/gns3_server.conf
+++ b/conf/gns3_server.conf
@@ -55,6 +55,9 @@ password = gns3
 ; Do not forget to allow virbr0 in order for the NAT node to work
 allowed_interfaces = eth0,eth1,virbr0
 
+; Only allow these mount points to be listed for statistics
+allowed_mountpoints = /opt,/home
+
 ; Specify the NAT interface to be used by the NAT node
 ; Default is virbr0 on Linux (requires libvirt) and vmnet8 for other platforms (requires VMware)
 default_nat_interface = vmnet10

--- a/gns3server/schemas/server_statistics.py
+++ b/gns3server/schemas/server_statistics.py
@@ -68,7 +68,7 @@ SERVER_STATISTICS_SCHEMA = {
             "type": "integer",
         },
         "disk_usage_percent": {
-            "description": "Disk usage in percent",
+            "description": "Disk usage in percent for all mountpoints",
             "type": "array",
         },
         "load_average_percent": {

--- a/gns3server/schemas/server_statistics.py
+++ b/gns3server/schemas/server_statistics.py
@@ -69,7 +69,7 @@ SERVER_STATISTICS_SCHEMA = {
         },
         "disk_usage_percent": {
             "description": "Disk usage in percent",
-            "type": "integer",
+            "type": "array",
         },
         "load_average_percent": {
             "description": "Average system load over the last 1, 5 and 15 minutes",


### PR DESCRIPTION
Mount points can be restricted using a new setting `allowed_mountpoints` in gns3_server.conf