### PR TITLE
REST API example needs additional parameter

### DIFF
--- a/gns3server/api/routes/controller/users.py
+++ b/gns3server/api/routes/controller/users.py
@@ -74,7 +74,7 @@ async def authenticate(
 ) -> schemas.Token:
     """
     Alternative authentication method using json.
-    Example: curl http://host:port/v3/users/authenticate -d '{"username": "admin", "password": "admin"}'
+    Example: curl http://host:port/v3/users/authenticate -d '{"username": "admin", "password": "admin"} -H "Content-Type: application/json" '
     """
 
     user = await users_repo.authenticate_user(username=user_credentials.username, password=user_credentials.password)


### PR DESCRIPTION
While trying this example with GNS3 branch 3.0 on Ubuntu 18.04.5 LTS, the REST API call 
```$ curl http://172.17.46.114:3080/v3/users/authenticate -d '{"username": "admin", "password": "admin"}' ``` 
fails with ```{"detail":[{"loc":["body"],"msg":"value is not a valid dict","type":"type_error.dict"}]}```.

The additional parameter appended to curl fixes this ```{"access_token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhZG1pbiIsImV4cCI6MTYzMTI4NTc4NX0.kT1dAN4v1vHMTBJO2UaI2I7yAFhnSpBU9iqmdDuwtAQ","token_type":"bearer"} ```

Found while googling for the error above in 
FastAPI 0.65.2 POST request fails with "value is not a valid dict" when using the Requests library; 0.65.1 works (with a caveat) #3373   https://github.com/tiangolo/fastapi/issues/3373#issuecomment-886745123