### PR TITLE
Remove explicit Response for endpoints returning HTTP 204 status code

### DIFF
--- a/gns3server/api/routes/compute/atm_switch_nodes.py
+++ b/gns3server/api/routes/compute/atm_switch_nodes.py
@@ -109,43 +109,42 @@ async def update_atm_switch(
 
 
 @router.delete("/{node_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_atm_switch_node(node: ATMSwitch = Depends(dep_node)) -> Response:
+async def delete_atm_switch_node(node: ATMSwitch = Depends(dep_node)) -> None:
     """
     Delete an ATM switch node.
     """
 
     await Dynamips.instance().delete_node(node.id)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/start", status_code=status.HTTP_204_NO_CONTENT)
-def start_atm_switch(node: ATMSwitch = Depends(dep_node)) -> Response:
+def start_atm_switch(node: ATMSwitch = Depends(dep_node)) -> None:
     """
     Start an ATM switch node.
     This endpoint results in no action since ATM switch nodes are always on.
     """
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    pass
 
 
 @router.post("/{node_id}/stop", status_code=status.HTTP_204_NO_CONTENT)
-def stop_atm_switch(node: ATMSwitch = Depends(dep_node)) -> Response:
+def stop_atm_switch(node: ATMSwitch = Depends(dep_node)) -> None:
     """
     Stop an ATM switch node.
     This endpoint results in no action since ATM switch nodes are always on.
     """
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    pass
 
 
 @router.post("/{node_id}/suspend", status_code=status.HTTP_204_NO_CONTENT)
-def suspend_atm_switch(node: ATMSwitch = Depends(dep_node)) -> Response:
+def suspend_atm_switch(node: ATMSwitch = Depends(dep_node)) -> None:
     """
     Suspend an ATM switch node.
     This endpoint results in no action since ATM switch nodes are always on.
     """
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    pass
 
 
 @router.post(
@@ -171,7 +170,7 @@ async def create_nio(
 
 
 @router.delete("/{node_id}/adapters/{adapter_number}/ports/{port_number}/nio", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_nio(adapter_number: int, port_number: int, node: ATMSwitch = Depends(dep_node)) -> Response:
+async def delete_nio(adapter_number: int, port_number: int, node: ATMSwitch = Depends(dep_node)) -> None:
     """
     Remove a NIO (Network Input/Output) from the node.
     The adapter number on the switch is always 0.
@@ -179,7 +178,6 @@ async def delete_nio(adapter_number: int, port_number: int, node: ATMSwitch = De
 
     nio = await node.remove_nio(port_number)
     await nio.delete()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/start")
@@ -209,14 +207,13 @@ async def stop_capture(
         adapter_number: int = Path(..., ge=0, le=0),
         port_number: int,
         node: ATMSwitch = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Stop a packet capture on the node.
     The adapter number on the switch is always 0.
     """
 
     await node.stop_capture(port_number)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/stream")

--- a/gns3server/api/routes/compute/cloud_nodes.py
+++ b/gns3server/api/routes/compute/cloud_nodes.py
@@ -99,43 +99,41 @@ def update_cloud(node_data: schemas.CloudUpdate, node: Cloud = Depends(dep_node)
 
 
 @router.delete("/{node_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_cloud(node: Cloud = Depends(dep_node)) -> Response:
+async def delete_cloud(node: Cloud = Depends(dep_node)) -> None:
     """
     Delete a cloud node.
     """
 
     await Builtin.instance().delete_node(node.id)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/start", status_code=status.HTTP_204_NO_CONTENT)
-async def start_cloud(node: Cloud = Depends(dep_node)) -> Response:
+async def start_cloud(node: Cloud = Depends(dep_node)) -> None:
     """
     Start a cloud node.
     """
 
     await node.start()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/stop", status_code=status.HTTP_204_NO_CONTENT)
-async def stop_cloud(node: Cloud = Depends(dep_node)) -> Response:
+async def stop_cloud(node: Cloud = Depends(dep_node)) -> None:
     """
     Stop a cloud node.
     This endpoint results in no action since cloud nodes cannot be stopped.
     """
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    pass
 
 
 @router.post("/{node_id}/suspend", status_code=status.HTTP_204_NO_CONTENT)
-async def suspend_cloud(node: Cloud = Depends(dep_node)) -> Response:
+async def suspend_cloud(node: Cloud = Depends(dep_node)) -> None:
     """
     Suspend a cloud node.
     This endpoint results in no action since cloud nodes cannot be suspended.
     """
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    pass
 
 
 @router.post(
@@ -190,14 +188,13 @@ async def delete_cloud_nio(
         adapter_number: int = Path(..., ge=0, le=0),
         port_number: int,
         node: Cloud = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Remove a NIO (Network Input/Output) from the node.
     The adapter number on the cloud is always 0.
     """
 
     await node.remove_nio(port_number)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/start")
@@ -226,14 +223,13 @@ async def stop_cloud_capture(
         adapter_number: int = Path(..., ge=0, le=0),
         port_number: int,
         node: Cloud = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Stop a packet capture on the node.
     The adapter number on the cloud is always 0.
     """
 
     await node.stop_capture(port_number)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{node_id}/adapters/{adapter_number}/ports/{port_number}/pcap")

--- a/gns3server/api/routes/compute/docker_nodes.py
+++ b/gns3server/api/routes/compute/docker_nodes.py
@@ -132,73 +132,66 @@ async def update_docker_node(node_data: schemas.DockerUpdate, node: DockerVM = D
 
 
 @router.post("/{node_id}/start", status_code=status.HTTP_204_NO_CONTENT)
-async def start_docker_node(node: DockerVM = Depends(dep_node)) -> Response:
+async def start_docker_node(node: DockerVM = Depends(dep_node)) -> None:
     """
     Start a Docker node.
     """
 
     await node.start()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/stop", status_code=status.HTTP_204_NO_CONTENT)
-async def stop_docker_node(node: DockerVM = Depends(dep_node)) -> Response:
+async def stop_docker_node(node: DockerVM = Depends(dep_node)) -> None:
     """
     Stop a Docker node.
     """
 
     await node.stop()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/suspend", status_code=status.HTTP_204_NO_CONTENT)
-async def suspend_docker_node(node: DockerVM = Depends(dep_node)) -> Response:
+async def suspend_docker_node(node: DockerVM = Depends(dep_node)) -> None:
     """
     Suspend a Docker node.
     """
 
     await node.pause()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/reload", status_code=status.HTTP_204_NO_CONTENT)
-async def reload_docker_node(node: DockerVM = Depends(dep_node)) -> Response:
+async def reload_docker_node(node: DockerVM = Depends(dep_node)) -> None:
     """
     Reload a Docker node.
     """
 
     await node.restart()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/pause", status_code=status.HTTP_204_NO_CONTENT)
-async def pause_docker_node(node: DockerVM = Depends(dep_node)) -> Response:
+async def pause_docker_node(node: DockerVM = Depends(dep_node)) -> None:
     """
     Pause a Docker node.
     """
 
     await node.pause()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/unpause", status_code=status.HTTP_204_NO_CONTENT)
-async def unpause_docker_node(node: DockerVM = Depends(dep_node)) -> Response:
+async def unpause_docker_node(node: DockerVM = Depends(dep_node)) -> None:
     """
     Unpause a Docker node.
     """
 
     await node.unpause()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.delete("/{node_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_docker_node(node: DockerVM = Depends(dep_node)) -> Response:
+async def delete_docker_node(node: DockerVM = Depends(dep_node)) -> None:
     """
     Delete a Docker node.
     """
 
     await node.delete()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/duplicate", response_model=schemas.Docker, status_code=status.HTTP_201_CREATED)
@@ -257,14 +250,13 @@ async def delete_docker_node_nio(
         adapter_number: int,
         port_number: int,
         node: DockerVM = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Delete a NIO (Network Input/Output) from the node.
     The port number on the Docker node is always 0.
     """
 
     await node.adapter_remove_nio_binding(adapter_number)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/start")
@@ -292,14 +284,13 @@ async def stop_docker_node_capture(
         adapter_number: int,
         port_number: int,
         node: DockerVM = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Stop a packet capture on the node.
     The port number on the Docker node is always 0.
     """
 
     await node.stop_capture(adapter_number)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/stream")
@@ -328,7 +319,6 @@ async def console_ws(websocket: WebSocket, node: DockerVM = Depends(dep_node)) -
 
 
 @router.post("/{node_id}/console/reset", status_code=status.HTTP_204_NO_CONTENT)
-async def reset_console(node: DockerVM = Depends(dep_node)) -> Response:
+async def reset_console(node: DockerVM = Depends(dep_node)) -> None:
 
     await node.reset_console()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/gns3server/api/routes/compute/dynamips_nodes.py
+++ b/gns3server/api/routes/compute/dynamips_nodes.py
@@ -105,17 +105,16 @@ async def update_router(node_data: schemas.DynamipsUpdate, node: Router = Depend
 
 
 @router.delete("/{node_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_router(node: Router = Depends(dep_node)) -> Response:
+async def delete_router(node: Router = Depends(dep_node)) -> None:
     """
     Delete a Dynamips router.
     """
 
     await Dynamips.instance().delete_node(node.id)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/start", status_code=status.HTTP_204_NO_CONTENT)
-async def start_router(node: Router = Depends(dep_node)) -> Response:
+async def start_router(node: Router = Depends(dep_node)) -> None:
     """
     Start a Dynamips router.
     """
@@ -125,44 +124,39 @@ async def start_router(node: Router = Depends(dep_node)) -> Response:
     except GeneratorExit:
         pass
     await node.start()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/stop", status_code=status.HTTP_204_NO_CONTENT)
-async def stop_router(node: Router = Depends(dep_node)) -> Response:
+async def stop_router(node: Router = Depends(dep_node)) -> None:
     """
     Stop a Dynamips router.
     """
 
     await node.stop()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/suspend", status_code=status.HTTP_204_NO_CONTENT)
-async def suspend_router(node: Router = Depends(dep_node)) -> Response:
+async def suspend_router(node: Router = Depends(dep_node)) -> None:
 
     await node.suspend()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/resume", status_code=status.HTTP_204_NO_CONTENT)
-async def resume_router(node: Router = Depends(dep_node)) -> Response:
+async def resume_router(node: Router = Depends(dep_node)) -> None:
     """
     Resume a suspended Dynamips router.
     """
 
     await node.resume()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/reload", status_code=status.HTTP_204_NO_CONTENT)
-async def reload_router(node: Router = Depends(dep_node)) -> Response:
+async def reload_router(node: Router = Depends(dep_node)) -> None:
     """
     Reload a suspended Dynamips router.
     """
 
     await node.reload()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post(
@@ -208,14 +202,13 @@ async def update_nio(
 
 
 @router.delete("/{node_id}/adapters/{adapter_number}/ports/{port_number}/nio", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_nio(adapter_number: int, port_number: int, node: Router = Depends(dep_node)) -> Response:
+async def delete_nio(adapter_number: int, port_number: int, node: Router = Depends(dep_node)) -> None:
     """
     Delete a NIO (Network Input/Output) from the node.
     """
 
     nio = await node.slot_remove_nio_binding(adapter_number, port_number)
     await nio.delete()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/start")
@@ -237,13 +230,12 @@ async def start_capture(
 @router.post(
     "/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/stop", status_code=status.HTTP_204_NO_CONTENT
 )
-async def stop_capture(adapter_number: int, port_number: int, node: Router = Depends(dep_node)) -> Response:
+async def stop_capture(adapter_number: int, port_number: int, node: Router = Depends(dep_node)) -> None:
     """
     Stop a packet capture on the node.
     """
 
     await node.stop_capture(adapter_number, port_number)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/stream")
@@ -301,7 +293,6 @@ async def console_ws(websocket: WebSocket, node: Router = Depends(dep_node)) -> 
 
 
 @router.post("/{node_id}/console/reset", status_code=status.HTTP_204_NO_CONTENT)
-async def reset_console(node: Router = Depends(dep_node)) -> Response:
+async def reset_console(node: Router = Depends(dep_node)) -> None:
 
     await node.reset_console()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/gns3server/api/routes/compute/ethernet_hub_nodes.py
+++ b/gns3server/api/routes/compute/ethernet_hub_nodes.py
@@ -108,43 +108,42 @@ async def update_ethernet_hub(
 
 
 @router.delete("/{node_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_ethernet_hub(node: EthernetHub = Depends(dep_node)) -> Response:
+async def delete_ethernet_hub(node: EthernetHub = Depends(dep_node)) -> None:
     """
     Delete an Ethernet hub.
     """
 
     await Dynamips.instance().delete_node(node.id)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/start", status_code=status.HTTP_204_NO_CONTENT)
-def start_ethernet_hub(node: EthernetHub = Depends(dep_node)) -> Response:
+def start_ethernet_hub(node: EthernetHub = Depends(dep_node)) -> None:
     """
     Start an Ethernet hub.
     This endpoint results in no action since Ethernet hub nodes are always on.
     """
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    pass
 
 
 @router.post("/{node_id}/stop", status_code=status.HTTP_204_NO_CONTENT)
-def stop_ethernet_hub(node: EthernetHub = Depends(dep_node)) -> Response:
+def stop_ethernet_hub(node: EthernetHub = Depends(dep_node)) -> None:
     """
     Stop an Ethernet hub.
     This endpoint results in no action since Ethernet hub nodes are always on.
     """
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    pass
 
 
 @router.post("/{node_id}/suspend", status_code=status.HTTP_204_NO_CONTENT)
-def suspend_ethernet_hub(node: EthernetHub = Depends(dep_node)) -> Response:
+def suspend_ethernet_hub(node: EthernetHub = Depends(dep_node)) -> None:
     """
     Suspend an Ethernet hub.
     This endpoint results in no action since Ethernet hub nodes are always on.
     """
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    pass
 
 
 @router.post(
@@ -175,7 +174,7 @@ async def delete_nio(
         adapter_number: int = Path(..., ge=0, le=0),
         port_number: int,
         node: EthernetHub = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Delete a NIO (Network Input/Output) from the node.
     The adapter number on the hub is always 0.
@@ -183,7 +182,6 @@ async def delete_nio(
 
     nio = await node.remove_nio(port_number)
     await nio.delete()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/start")
@@ -212,14 +210,13 @@ async def stop_capture(
         adapter_number: int = Path(..., ge=0, le=0),
         port_number: int,
         node: EthernetHub = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Stop a packet capture on the node.
     The adapter number on the hub is always 0.
     """
 
     await node.stop_capture(port_number)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/stream")

--- a/gns3server/api/routes/compute/ethernet_switch_nodes.py
+++ b/gns3server/api/routes/compute/ethernet_switch_nodes.py
@@ -112,43 +112,42 @@ async def update_ethernet_switch(
 
 
 @router.delete("/{node_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_ethernet_switch(node: EthernetSwitch = Depends(dep_node)) -> Response:
+async def delete_ethernet_switch(node: EthernetSwitch = Depends(dep_node)) -> None:
     """
     Delete an Ethernet switch.
     """
 
     await Dynamips.instance().delete_node(node.id)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/start", status_code=status.HTTP_204_NO_CONTENT)
-def start_ethernet_switch(node: EthernetSwitch = Depends(dep_node)) -> Response:
+def start_ethernet_switch(node: EthernetSwitch = Depends(dep_node)) -> None:
     """
     Start an Ethernet switch.
     This endpoint results in no action since Ethernet switch nodes are always on.
     """
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    pass
 
 
 @router.post("/{node_id}/stop", status_code=status.HTTP_204_NO_CONTENT)
-def stop_ethernet_switch(node: EthernetSwitch = Depends(dep_node)) -> Response:
+def stop_ethernet_switch(node: EthernetSwitch = Depends(dep_node)) -> None:
     """
     Stop an Ethernet switch.
     This endpoint results in no action since Ethernet switch nodes are always on.
     """
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    pass
 
 
 @router.post("/{node_id}/suspend", status_code=status.HTTP_204_NO_CONTENT)
-def suspend_ethernet_switch(node: EthernetSwitch = Depends(dep_node)) -> Response:
+def suspend_ethernet_switch(node: EthernetSwitch = Depends(dep_node)) -> None:
     """
     Suspend an Ethernet switch.
     This endpoint results in no action since Ethernet switch nodes are always on.
     """
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    pass
 
 
 @router.post(
@@ -175,7 +174,7 @@ async def delete_nio(
         adapter_number: int = Path(..., ge=0, le=0),
         port_number: int,
         node: EthernetSwitch = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Delete a NIO (Network Input/Output) from the node.
     The adapter number on the switch is always 0.
@@ -183,7 +182,6 @@ async def delete_nio(
 
     nio = await node.remove_nio(port_number)
     await nio.delete()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/start")
@@ -212,14 +210,13 @@ async def stop_capture(
         adapter_number: int = Path(..., ge=0, le=0),
         port_number: int,
         node: EthernetSwitch = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Stop a packet capture on the node.
     The adapter number on the switch is always 0.
     """
 
     await node.stop_capture(port_number)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/stream")

--- a/gns3server/api/routes/compute/frame_relay_switch_nodes.py
+++ b/gns3server/api/routes/compute/frame_relay_switch_nodes.py
@@ -112,43 +112,42 @@ async def update_frame_relay_switch(
 
 
 @router.delete("/{node_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_frame_relay_switch(node: FrameRelaySwitch = Depends(dep_node)) -> Response:
+async def delete_frame_relay_switch(node: FrameRelaySwitch = Depends(dep_node)) -> None:
     """
     Delete a Frame Relay switch node.
     """
 
     await Dynamips.instance().delete_node(node.id)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/start", status_code=status.HTTP_204_NO_CONTENT)
-def start_frame_relay_switch(node: FrameRelaySwitch = Depends(dep_node)) -> Response:
+def start_frame_relay_switch(node: FrameRelaySwitch = Depends(dep_node)) -> None:
     """
     Start a Frame Relay switch node.
     This endpoint results in no action since Frame Relay switch nodes are always on.
     """
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    pass
 
 
 @router.post("/{node_id}/stop", status_code=status.HTTP_204_NO_CONTENT)
-def stop_frame_relay_switch(node: FrameRelaySwitch = Depends(dep_node)) -> Response:
+def stop_frame_relay_switch(node: FrameRelaySwitch = Depends(dep_node)) -> None:
     """
     Stop a Frame Relay switch node.
     This endpoint results in no action since Frame Relay switch nodes are always on.
     """
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    pass
 
 
 @router.post("/{node_id}/suspend", status_code=status.HTTP_204_NO_CONTENT)
-def suspend_frame_relay_switch(node: FrameRelaySwitch = Depends(dep_node)) -> Response:
+def suspend_frame_relay_switch(node: FrameRelaySwitch = Depends(dep_node)) -> None:
     """
     Suspend a Frame Relay switch node.
     This endpoint results in no action since Frame Relay switch nodes are always on.
     """
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    pass
 
 
 @router.post(
@@ -179,7 +178,7 @@ async def delete_nio(
         adapter_number: int = Path(..., ge=0, le=0),
         port_number: int,
         node: FrameRelaySwitch = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Remove a NIO (Network Input/Output) from the node.
     The adapter number on the switch is always 0.
@@ -187,7 +186,6 @@ async def delete_nio(
 
     nio = await node.remove_nio(port_number)
     await nio.delete()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/start")
@@ -216,14 +214,13 @@ async def stop_capture(
         adapter_number: int = Path(..., ge=0, le=0),
         port_number: int,
         node: FrameRelaySwitch = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Stop a packet capture on the node.
     The adapter number on the switch is always 0.
     """
 
     await node.stop_capture(port_number)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/stream")

--- a/gns3server/api/routes/compute/images.py
+++ b/gns3server/api/routes/compute/images.py
@@ -54,14 +54,13 @@ async def get_dynamips_images() -> List[str]:
 
 
 @router.post("/dynamips/images/{filename:path}", status_code=status.HTTP_204_NO_CONTENT)
-async def upload_dynamips_image(filename: str, request: Request) -> Response:
+async def upload_dynamips_image(filename: str, request: Request) -> None:
     """
     Upload a Dynamips IOS image.
     """
 
     dynamips_manager = Dynamips.instance()
     await dynamips_manager.write_image(urllib.parse.unquote(filename), request.stream())
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/dynamips/images/{filename:path}")
@@ -96,14 +95,13 @@ async def get_iou_images() -> List[str]:
 
 
 @router.post("/iou/images/{filename:path}", status_code=status.HTTP_204_NO_CONTENT)
-async def upload_iou_image(filename: str, request: Request) -> Response:
+async def upload_iou_image(filename: str, request: Request) -> None:
     """
     Upload an IOU image.
     """
 
     iou_manager = IOU.instance()
     await iou_manager.write_image(urllib.parse.unquote(filename), request.stream())
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/iou/images/{filename:path}")
@@ -134,11 +132,10 @@ async def get_qemu_images() -> List[str]:
 
 
 @router.post("/qemu/images/{filename:path}", status_code=status.HTTP_204_NO_CONTENT)
-async def upload_qemu_image(filename: str, request: Request) -> Response:
+async def upload_qemu_image(filename: str, request: Request) -> None:
 
     qemu_manager = Qemu.instance()
     await qemu_manager.write_image(urllib.parse.unquote(filename), request.stream())
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/qemu/images/{filename:path}")

--- a/gns3server/api/routes/compute/iou_nodes.py
+++ b/gns3server/api/routes/compute/iou_nodes.py
@@ -113,13 +113,12 @@ async def update_iou_node(node_data: schemas.IOUUpdate, node: IOUVM = Depends(de
 
 
 @router.delete("/{node_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_iou_node(node: IOUVM = Depends(dep_node)) -> Response:
+async def delete_iou_node(node: IOUVM = Depends(dep_node)) -> None:
     """
     Delete an IOU node.
     """
 
     await IOU.instance().delete_node(node.id)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/duplicate", response_model=schemas.IOU, status_code=status.HTTP_201_CREATED)
@@ -136,7 +135,7 @@ async def duplicate_iou_node(
 
 
 @router.post("/{node_id}/start", status_code=status.HTTP_204_NO_CONTENT)
-async def start_iou_node(start_data: schemas.IOUStart, node: IOUVM = Depends(dep_node)) -> Response:
+async def start_iou_node(start_data: schemas.IOUStart, node: IOUVM = Depends(dep_node)) -> None:
     """
     Start an IOU node.
     """
@@ -147,37 +146,34 @@ async def start_iou_node(start_data: schemas.IOUStart, node: IOUVM = Depends(dep
             setattr(node, name, value)
 
     await node.start()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/stop", status_code=status.HTTP_204_NO_CONTENT)
-async def stop_iou_node(node: IOUVM = Depends(dep_node)) -> Response:
+async def stop_iou_node(node: IOUVM = Depends(dep_node)) -> None:
     """
     Stop an IOU node.
     """
 
     await node.stop()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/stop", status_code=status.HTTP_204_NO_CONTENT)
-def suspend_iou_node(node: IOUVM = Depends(dep_node)) -> Response:
+def suspend_iou_node(node: IOUVM = Depends(dep_node)) -> None:
     """
     Suspend an IOU node.
     Does nothing since IOU doesn't support being suspended.
     """
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    pass
 
 
 @router.post("/{node_id}/reload", status_code=status.HTTP_204_NO_CONTENT)
-async def reload_iou_node(node: IOUVM = Depends(dep_node)) -> Response:
+async def reload_iou_node(node: IOUVM = Depends(dep_node)) -> None:
     """
     Reload an IOU node.
     """
 
     await node.reload()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post(
@@ -223,13 +219,12 @@ async def update_iou_node_nio(
 
 
 @router.delete("/{node_id}/adapters/{adapter_number}/ports/{port_number}/nio", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_iou_node_nio(adapter_number: int, port_number: int, node: IOUVM = Depends(dep_node)) -> Response:
+async def delete_iou_node_nio(adapter_number: int, port_number: int, node: IOUVM = Depends(dep_node)) -> None:
     """
     Delete a NIO (Network Input/Output) from the node.
     """
 
     await node.adapter_remove_nio_binding(adapter_number, port_number)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/start")
@@ -251,13 +246,12 @@ async def start_iou_node_capture(
 @router.post(
     "/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/stop", status_code=status.HTTP_204_NO_CONTENT
 )
-async def stop_iou_node_capture(adapter_number: int, port_number: int, node: IOUVM = Depends(dep_node)) -> Response:
+async def stop_iou_node_capture(adapter_number: int, port_number: int, node: IOUVM = Depends(dep_node)) -> None:
     """
     Stop a packet capture on the node.
     """
 
     await node.stop_capture(adapter_number, port_number)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/stream")
@@ -285,7 +279,6 @@ async def console_ws(websocket: WebSocket, node: IOUVM = Depends(dep_node)) -> N
 
 
 @router.post("/{node_id}/console/reset", status_code=status.HTTP_204_NO_CONTENT)
-async def reset_console(node: IOUVM = Depends(dep_node)) -> Response:
+async def reset_console(node: IOUVM = Depends(dep_node)) -> None:
 
     await node.reset_console()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/gns3server/api/routes/compute/nat_nodes.py
+++ b/gns3server/api/routes/compute/nat_nodes.py
@@ -94,43 +94,41 @@ def update_nat_node(node_data: schemas.NATUpdate, node: Nat = Depends(dep_node))
 
 
 @router.delete("/{node_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_nat_node(node: Nat = Depends(dep_node)) -> Response:
+async def delete_nat_node(node: Nat = Depends(dep_node)) -> None:
     """
     Delete a cloud node.
     """
 
     await Builtin.instance().delete_node(node.id)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/start", status_code=status.HTTP_204_NO_CONTENT)
-async def start_nat_node(node: Nat = Depends(dep_node)) -> Response:
+async def start_nat_node(node: Nat = Depends(dep_node)) -> None:
     """
     Start a NAT node.
     """
 
     await node.start()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/stop", status_code=status.HTTP_204_NO_CONTENT)
-async def stop_nat_node(node: Nat = Depends(dep_node)) -> Response:
+async def stop_nat_node(node: Nat = Depends(dep_node)) -> None:
     """
     Stop a NAT node.
     This endpoint results in no action since cloud nodes cannot be stopped.
     """
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    pass
 
 
 @router.post("/{node_id}/suspend", status_code=status.HTTP_204_NO_CONTENT)
-async def suspend_nat_node(node: Nat = Depends(dep_node)) -> Response:
+async def suspend_nat_node(node: Nat = Depends(dep_node)) -> None:
     """
     Suspend a NAT node.
     This endpoint results in no action since NAT nodes cannot be suspended.
     """
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    pass
 
 
 @router.post(
@@ -185,14 +183,13 @@ async def delete_nat_node_nio(
         adapter_number: int = Path(..., ge=0, le=0),
         port_number: int,
         node: Nat = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Remove a NIO (Network Input/Output) from the node.
     The adapter number on the cloud is always 0.
     """
 
     await node.remove_nio(port_number)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/start")
@@ -221,14 +218,13 @@ async def stop_nat_node_capture(
         adapter_number: int = Path(..., ge=0, le=0),
         port_number: int,
         node: Nat = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Stop a packet capture on the node.
     The adapter number on the cloud is always 0.
     """
 
     await node.stop_capture(port_number)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/stream")

--- a/gns3server/api/routes/compute/projects.py
+++ b/gns3server/api/routes/compute/projects.py
@@ -103,7 +103,7 @@ def get_compute_project(project: Project = Depends(dep_project)) -> schemas.Proj
 
 
 @router.post("/projects/{project_id}/close", status_code=status.HTTP_204_NO_CONTENT)
-async def close_compute_project(project: Project = Depends(dep_project)) -> Response:
+async def close_compute_project(project: Project = Depends(dep_project)) -> None:
     """
     Close a project on the compute.
     """
@@ -118,18 +118,16 @@ async def close_compute_project(project: Project = Depends(dep_project)) -> Resp
             pass
     else:
         log.warning("Skip project closing, another client is listening for project notifications")
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.delete("/projects/{project_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_compute_project(project: Project = Depends(dep_project)) -> Response:
+async def delete_compute_project(project: Project = Depends(dep_project)) -> None:
     """
     Delete project from the compute.
     """
 
     await project.delete()
     ProjectManager.instance().remove_project(project.id)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 # @Route.get(
 #     r"/projects/{project_id}/notifications",
@@ -219,7 +217,7 @@ async def write_compute_project_file(
         file_path: str,
         request: Request,
         project: Project = Depends(dep_project)
-) -> Response:
+) -> None:
 
     file_path = urllib.parse.unquote(file_path)
     path = os.path.normpath(file_path)
@@ -243,5 +241,3 @@ async def write_compute_project_file(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     except PermissionError:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
-
-    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/gns3server/api/routes/compute/qemu_nodes.py
+++ b/gns3server/api/routes/compute/qemu_nodes.py
@@ -104,13 +104,12 @@ async def update_qemu_node(node_data: schemas.QemuUpdate, node: QemuVM = Depends
 
 
 @router.delete("/{node_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_qemu_node(node: QemuVM = Depends(dep_node)) -> Response:
+async def delete_qemu_node(node: QemuVM = Depends(dep_node)) -> None:
     """
     Delete a Qemu node.
     """
 
     await Qemu.instance().delete_node(node.id)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/duplicate", response_model=schemas.Qemu, status_code=status.HTTP_201_CREATED)
@@ -134,14 +133,13 @@ async def create_qemu_disk_image(
         disk_name: str,
         disk_data: schemas.QemuDiskImageCreate,
         node: QemuVM = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Create a Qemu disk image.
     """
 
     options = jsonable_encoder(disk_data, exclude_unset=True)
     await node.create_disk_image(disk_name, options)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.put(
@@ -152,14 +150,13 @@ async def update_qemu_disk_image(
         disk_name: str,
         disk_data: schemas.QemuDiskImageUpdate,
         node: QemuVM = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Update a Qemu disk image.
     """
 
     if disk_data.extend:
         await node.resize_disk_image(disk_name, disk_data.extend)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.delete(
@@ -169,63 +166,57 @@ async def update_qemu_disk_image(
 async def delete_qemu_disk_image(
         disk_name: str,
         node: QemuVM = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Delete a Qemu disk image.
     """
 
     node.delete_disk_image(disk_name)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/start", status_code=status.HTTP_204_NO_CONTENT)
-async def start_qemu_node(node: QemuVM = Depends(dep_node)) -> Response:
+async def start_qemu_node(node: QemuVM = Depends(dep_node)) -> None:
     """
     Start a Qemu node.
     """
 
     await node.start()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/stop", status_code=status.HTTP_204_NO_CONTENT)
-async def stop_qemu_node(node: QemuVM = Depends(dep_node)) -> Response:
+async def stop_qemu_node(node: QemuVM = Depends(dep_node)) -> None:
     """
     Stop a Qemu node.
     """
 
     await node.stop()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/reload", status_code=status.HTTP_204_NO_CONTENT)
-async def reload_qemu_node(node: QemuVM = Depends(dep_node)) -> Response:
+async def reload_qemu_node(node: QemuVM = Depends(dep_node)) -> None:
     """
     Reload a Qemu node.
     """
 
     await node.reload()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/suspend", status_code=status.HTTP_204_NO_CONTENT)
-async def suspend_qemu_node(node: QemuVM = Depends(dep_node)) -> Response:
+async def suspend_qemu_node(node: QemuVM = Depends(dep_node)) -> None:
     """
     Suspend a Qemu node.
     """
 
     await node.suspend()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/resume", status_code=status.HTTP_204_NO_CONTENT)
-async def resume_qemu_node(node: QemuVM = Depends(dep_node)) -> Response:
+async def resume_qemu_node(node: QemuVM = Depends(dep_node)) -> None:
     """
     Resume a Qemu node.
     """
 
     await node.resume()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post(
@@ -281,14 +272,13 @@ async def delete_qemu_node_nio(
         adapter_number: int,
         port_number: int = Path(..., ge=0, le=0),
         node: QemuVM = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Delete a NIO (Network Input/Output) from the node.
     The port number on the Qemu node is always 0.
     """
 
     await node.adapter_remove_nio_binding(adapter_number)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/start")
@@ -316,14 +306,13 @@ async def stop_qemu_node_capture(
         adapter_number: int,
         port_number: int = Path(..., ge=0, le=0),
         node: QemuVM = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Stop a packet capture on the node.
     The port number on the Qemu node is always 0.
     """
 
     await node.stop_capture(adapter_number)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/stream")
@@ -351,7 +340,6 @@ async def console_ws(websocket: WebSocket, node: QemuVM = Depends(dep_node)) -> 
 
 
 @router.post("/{node_id}/console/reset", status_code=status.HTTP_204_NO_CONTENT)
-async def reset_console(node: QemuVM = Depends(dep_node)) -> Response:
+async def reset_console(node: QemuVM = Depends(dep_node)) -> None:
 
     await node.reset_console()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/gns3server/api/routes/compute/virtualbox_nodes.py
+++ b/gns3server/api/routes/compute/virtualbox_nodes.py
@@ -137,63 +137,57 @@ async def update_virtualbox_node(
 
 
 @router.delete("/{node_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_virtualbox_node(node: VirtualBoxVM = Depends(dep_node)) -> Response:
+async def delete_virtualbox_node(node: VirtualBoxVM = Depends(dep_node)) -> None:
     """
     Delete a VirtualBox node.
     """
 
     await VirtualBox.instance().delete_node(node.id)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/start", status_code=status.HTTP_204_NO_CONTENT)
-async def start_virtualbox_node(node: VirtualBoxVM = Depends(dep_node)) -> Response:
+async def start_virtualbox_node(node: VirtualBoxVM = Depends(dep_node)) -> None:
     """
     Start a VirtualBox node.
     """
 
     await node.start()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/stop", status_code=status.HTTP_204_NO_CONTENT)
-async def stop_virtualbox_node(node: VirtualBoxVM = Depends(dep_node)) -> Response:
+async def stop_virtualbox_node(node: VirtualBoxVM = Depends(dep_node)) -> None:
     """
     Stop a VirtualBox node.
     """
 
     await node.stop()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/suspend", status_code=status.HTTP_204_NO_CONTENT)
-async def suspend_virtualbox_node(node: VirtualBoxVM = Depends(dep_node)) -> Response:
+async def suspend_virtualbox_node(node: VirtualBoxVM = Depends(dep_node)) -> None:
     """
     Suspend a VirtualBox node.
     """
 
     await node.suspend()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/resume", status_code=status.HTTP_204_NO_CONTENT)
-async def resume_virtualbox_node(node: VirtualBoxVM = Depends(dep_node)) -> Response:
+async def resume_virtualbox_node(node: VirtualBoxVM = Depends(dep_node)) -> None:
     """
     Resume a VirtualBox node.
     """
 
     await node.resume()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/reload", status_code=status.HTTP_204_NO_CONTENT)
-async def reload_virtualbox_node(node: VirtualBoxVM = Depends(dep_node)) -> Response:
+async def reload_virtualbox_node(node: VirtualBoxVM = Depends(dep_node)) -> None:
     """
     Reload a VirtualBox node.
     """
 
     await node.reload()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post(
@@ -249,14 +243,13 @@ async def delete_virtualbox_node_nio(
         adapter_number: int,
         port_number: int = Path(..., ge=0, le=0),
         node: VirtualBoxVM = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Delete a NIO (Network Input/Output) from the node.
     The port number on the VirtualBox node is always 0.
     """
 
     await node.adapter_remove_nio_binding(adapter_number)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/start")
@@ -284,14 +277,13 @@ async def stop_virtualbox_node_capture(
         adapter_number: int,
         port_number: int = Path(..., ge=0, le=0),
         node: VirtualBoxVM = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Stop a packet capture on the node.
     The port number on the VirtualBox node is always 0.
     """
 
     await node.stop_capture(adapter_number)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/stream")
@@ -320,7 +312,7 @@ async def console_ws(websocket: WebSocket, node: VirtualBoxVM = Depends(dep_node
 
 
 @router.post("/{node_id}/console/reset", status_code=status.HTTP_204_NO_CONTENT)
-async def reset_console(node: VirtualBoxVM = Depends(dep_node)) -> Response:
+async def reset_console(node: VirtualBoxVM = Depends(dep_node)) -> None:
 
     await node.reset_console()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+

--- a/gns3server/api/routes/compute/vmware_nodes.py
+++ b/gns3server/api/routes/compute/vmware_nodes.py
@@ -103,63 +103,57 @@ def update_vmware_node(node_data: schemas.VMwareUpdate, node: VMwareVM = Depends
 
 
 @router.delete("/{node_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_vmware_node(node: VMwareVM = Depends(dep_node)) -> Response:
+async def delete_vmware_node(node: VMwareVM = Depends(dep_node)) -> None:
     """
     Delete a VMware node.
     """
 
     await VMware.instance().delete_node(node.id)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/start", status_code=status.HTTP_204_NO_CONTENT)
-async def start_vmware_node(node: VMwareVM = Depends(dep_node)) -> Response:
+async def start_vmware_node(node: VMwareVM = Depends(dep_node)) -> None:
     """
     Start a VMware node.
     """
 
     await node.start()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/stop", status_code=status.HTTP_204_NO_CONTENT)
-async def stop_vmware_node(node: VMwareVM = Depends(dep_node)) -> Response:
+async def stop_vmware_node(node: VMwareVM = Depends(dep_node)) -> None:
     """
     Stop a VMware node.
     """
 
     await node.stop()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/suspend", status_code=status.HTTP_204_NO_CONTENT)
-async def suspend_vmware_node(node: VMwareVM = Depends(dep_node)) -> Response:
+async def suspend_vmware_node(node: VMwareVM = Depends(dep_node)) -> None:
     """
     Suspend a VMware node.
     """
 
     await node.suspend()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/resume", status_code=status.HTTP_204_NO_CONTENT)
-async def resume_vmware_node(node: VMwareVM = Depends(dep_node)) -> Response:
+async def resume_vmware_node(node: VMwareVM = Depends(dep_node)) -> None:
     """
     Resume a VMware node.
     """
 
     await node.resume()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/reload", status_code=status.HTTP_204_NO_CONTENT)
-async def reload_vmware_node(node: VMwareVM = Depends(dep_node)) -> Response:
+async def reload_vmware_node(node: VMwareVM = Depends(dep_node)) -> None:
     """
     Reload a VMware node.
     """
 
     await node.reload()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post(
@@ -213,14 +207,13 @@ async def delete_vmware_node_nio(
         adapter_number: int,
         port_number: int = Path(..., ge=0, le=0),
         node: VMwareVM = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Delete a NIO (Network Input/Output) from the node.
     The port number on the VMware node is always 0.
     """
 
     await node.adapter_remove_nio_binding(adapter_number)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/start")
@@ -248,14 +241,13 @@ async def stop_vmware_node_capture(
         adapter_number: int,
         port_number: int = Path(..., ge=0, le=0),
         node: VMwareVM = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Stop a packet capture on the node.
     The port number on the VMware node is always 0.
     """
 
     await node.stop_capture(adapter_number)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/stream")
@@ -297,7 +289,7 @@ async def console_ws(websocket: WebSocket, node: VMwareVM = Depends(dep_node)) -
 
 
 @router.post("/{node_id}/console/reset", status_code=status.HTTP_204_NO_CONTENT)
-async def reset_console(node: VMwareVM = Depends(dep_node)) -> Response:
+async def reset_console(node: VMwareVM = Depends(dep_node)) -> None:
 
     await node.reset_console()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+

--- a/gns3server/api/routes/compute/vpcs_nodes.py
+++ b/gns3server/api/routes/compute/vpcs_nodes.py
@@ -93,13 +93,12 @@ def update_vpcs_node(node_data: schemas.VPCSUpdate, node: VPCSVM = Depends(dep_n
 
 
 @router.delete("/{node_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_vpcs_node(node: VPCSVM = Depends(dep_node)) -> Response:
+async def delete_vpcs_node(node: VPCSVM = Depends(dep_node)) -> None:
     """
     Delete a VPCS node.
     """
 
     await VPCS.instance().delete_node(node.id)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/duplicate", response_model=schemas.VPCS, status_code=status.HTTP_201_CREATED)
@@ -115,43 +114,40 @@ async def duplicate_vpcs_node(
 
 
 @router.post("/{node_id}/start", status_code=status.HTTP_204_NO_CONTENT)
-async def start_vpcs_node(node: VPCSVM = Depends(dep_node)) -> Response:
+async def start_vpcs_node(node: VPCSVM = Depends(dep_node)) -> None:
     """
     Start a VPCS node.
     """
 
     await node.start()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/stop", status_code=status.HTTP_204_NO_CONTENT)
-async def stop_vpcs_node(node: VPCSVM = Depends(dep_node)) -> Response:
+async def stop_vpcs_node(node: VPCSVM = Depends(dep_node)) -> None:
     """
     Stop a VPCS node.
     """
 
     await node.stop()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/suspend", status_code=status.HTTP_204_NO_CONTENT)
-async def suspend_vpcs_node(node: VPCSVM = Depends(dep_node)) -> Response:
+async def suspend_vpcs_node(node: VPCSVM = Depends(dep_node)) -> None:
     """
     Suspend a VPCS node.
     Does nothing, suspend is not supported by VPCS.
     """
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    pass
 
 
 @router.post("/{node_id}/reload", status_code=status.HTTP_204_NO_CONTENT)
-async def reload_vpcs_node(node: VPCSVM = Depends(dep_node)) -> Response:
+async def reload_vpcs_node(node: VPCSVM = Depends(dep_node)) -> None:
     """
     Reload a VPCS node.
     """
 
     await node.reload()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post(
@@ -206,14 +202,13 @@ async def delete_vpcs_node_nio(
         adapter_number: int = Path(..., ge=0, le=0),
         port_number: int,
         node: VPCSVM = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Delete a NIO (Network Input/Output) from the node.
     The adapter number on the VPCS node is always 0.
     """
 
     await node.port_remove_nio_binding(port_number)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/start")
@@ -242,21 +237,19 @@ async def stop_vpcs_node_capture(
         adapter_number: int = Path(..., ge=0, le=0),
         port_number: int,
         node: VPCSVM = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Stop a packet capture on the node.
     The adapter number on the VPCS node is always 0.
     """
 
     await node.stop_capture(port_number)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/console/reset", status_code=status.HTTP_204_NO_CONTENT)
-async def reset_console(node: VPCSVM = Depends(dep_node)) -> Response:
+async def reset_console(node: VPCSVM = Depends(dep_node)) -> None:
 
     await node.reset_console()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{node_id}/adapters/{adapter_number}/ports/{port_number}/capture/stream")

--- a/gns3server/api/routes/controller/appliances.py
+++ b/gns3server/api/routes/controller/appliances.py
@@ -106,7 +106,7 @@ async def install_appliance(
         templates_repo: TemplatesRepository = Depends(get_repository(TemplatesRepository)),
         current_user: schemas.User = Depends(get_current_active_user),
         rbac_repo: RbacRepository = Depends(get_repository(RbacRepository))
-) -> Response:
+) -> None:
     """
     Install an appliance.
     """
@@ -120,4 +120,3 @@ async def install_appliance(
         rbac_repo,
         current_user
     )
-    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/gns3server/api/routes/controller/computes.py
+++ b/gns3server/api/routes/controller/computes.py
@@ -57,7 +57,7 @@ async def create_compute(
 
 
 @router.post("/{compute_id}/connect", status_code=status.HTTP_204_NO_CONTENT)
-async def connect_compute(compute_id: Union[str, UUID]) -> Response:
+async def connect_compute(compute_id: Union[str, UUID]) -> None:
     """
     Connect to compute on the controller.
     """
@@ -65,7 +65,6 @@ async def connect_compute(compute_id: Union[str, UUID]) -> Response:
     compute = Controller.instance().get_compute(str(compute_id))
     if not compute.connected:
         await compute.connect(report_failed_connection=True)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{compute_id}", response_model=schemas.Compute, response_model_exclude_unset=True)
@@ -106,13 +105,12 @@ async def update_compute(
 @router.delete("/{compute_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_compute(
     compute_id: Union[str, UUID], computes_repo: ComputesRepository = Depends(get_repository(ComputesRepository))
-) -> Response:
+) -> None:
     """
     Delete a compute from the controller.
     """
 
     await ComputesService(computes_repo).delete_compute(compute_id)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{compute_id}/docker/images", response_model=List[schemas.ComputeDockerImage])

--- a/gns3server/api/routes/controller/controller.py
+++ b/gns3server/api/routes/controller/controller.py
@@ -83,13 +83,12 @@ def check_version(version: schemas.Version) -> dict:
     dependencies=[Depends(get_current_active_user)],
     status_code=status.HTTP_204_NO_CONTENT,
 )
-async def reload() -> Response:
+async def reload() -> None:
     """
     Reload the controller
     """
 
     await Controller.instance().reload()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post(
@@ -98,7 +97,7 @@ async def reload() -> Response:
     status_code=status.HTTP_204_NO_CONTENT,
     responses={403: {"model": schemas.ErrorMessage, "description": "Server shutdown not allowed"}},
 )
-async def shutdown() -> Response:
+async def shutdown() -> None:
     """
     Shutdown the server
     """
@@ -126,7 +125,6 @@ async def shutdown() -> Response:
 
     # then shutdown the server itself
     os.kill(os.getpid(), signal.SIGTERM)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get(

--- a/gns3server/api/routes/controller/drawings.py
+++ b/gns3server/api/routes/controller/drawings.py
@@ -76,11 +76,10 @@ async def update_drawing(project_id: UUID, drawing_id: UUID, drawing_data: schem
 
 
 @router.delete("/{drawing_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_drawing(project_id: UUID, drawing_id: UUID) -> Response:
+async def delete_drawing(project_id: UUID, drawing_id: UUID) -> None:
     """
     Delete a drawing.
     """
 
     project = await Controller.instance().get_loaded_project(str(project_id))
     await project.delete_drawing(str(drawing_id))
-    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/gns3server/api/routes/controller/groups.py
+++ b/gns3server/api/routes/controller/groups.py
@@ -113,7 +113,7 @@ async def update_user_group(
 async def delete_user_group(
     user_group_id: UUID,
     users_repo: UsersRepository = Depends(get_repository(UsersRepository)),
-) -> Response:
+) -> None:
     """
     Delete an user group
     """
@@ -128,8 +128,6 @@ async def delete_user_group(
     success = await users_repo.delete_user_group(user_group_id)
     if not success:
         raise ControllerError(f"User group '{user_group_id}' could not be deleted")
-
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{user_group_id}/members", response_model=List[schemas.User])
@@ -152,7 +150,7 @@ async def add_member_to_group(
         user_group_id: UUID,
         user_id: UUID,
         users_repo: UsersRepository = Depends(get_repository(UsersRepository))
-) -> Response:
+) -> None:
     """
     Add member to an user group.
     """
@@ -165,8 +163,6 @@ async def add_member_to_group(
     if not user_group:
         raise ControllerNotFoundError(f"User group '{user_group_id}' not found")
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
-
 
 @router.delete(
     "/{user_group_id}/members/{user_id}",
@@ -176,7 +172,7 @@ async def remove_member_from_group(
     user_group_id: UUID,
     user_id: UUID,
     users_repo: UsersRepository = Depends(get_repository(UsersRepository)),
-) -> Response:
+) -> None:
     """
     Remove member from an user group.
     """
@@ -188,8 +184,6 @@ async def remove_member_from_group(
     user_group = await users_repo.remove_member_from_user_group(user_group_id, user)
     if not user_group:
         raise ControllerNotFoundError(f"User group '{user_group_id}' not found")
-
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{user_group_id}/roles", response_model=List[schemas.Role])
@@ -226,8 +220,6 @@ async def add_role_to_group(
     if not user_group:
         raise ControllerNotFoundError(f"User group '{user_group_id}' not found")
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
-
 
 @router.delete(
     "/{user_group_id}/roles/{role_id}",
@@ -238,7 +230,7 @@ async def remove_role_from_group(
     role_id: UUID,
     users_repo: UsersRepository = Depends(get_repository(UsersRepository)),
     rbac_repo: RbacRepository = Depends(get_repository(RbacRepository))
-) -> Response:
+) -> None:
     """
     Remove role from an user group.
     """
@@ -250,5 +242,3 @@ async def remove_role_from_group(
     user_group = await users_repo.remove_role_from_user_group(user_group_id, role)
     if not user_group:
         raise ControllerNotFoundError(f"User group '{user_group_id}' not found")
-
-    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/gns3server/api/routes/controller/images.py
+++ b/gns3server/api/routes/controller/images.py
@@ -129,7 +129,7 @@ async def get_image(
 async def delete_image(
         image_path: str,
         images_repo: ImagesRepository = Depends(get_repository(ImagesRepository)),
-) -> Response:
+) -> None:
     """
     Delete an image.
     """
@@ -159,16 +159,13 @@ async def delete_image(
     if not success:
         raise ControllerError(f"Image '{image_path}' could not be deleted")
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
-
 
 @router.post("/prune", status_code=status.HTTP_204_NO_CONTENT)
 async def prune_images(
         images_repo: ImagesRepository = Depends(get_repository(ImagesRepository)),
-) -> Response:
+) -> None:
     """
     Prune images not attached to any template.
     """
 
     await images_repo.prune_images()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/gns3server/api/routes/controller/links.py
+++ b/gns3server/api/routes/controller/links.py
@@ -136,14 +136,13 @@ async def update_link(link_data: schemas.LinkUpdate, link: Link = Depends(dep_li
 
 
 @router.delete("/{link_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_link(project_id: UUID, link: Link = Depends(dep_link)) -> Response:
+async def delete_link(project_id: UUID, link: Link = Depends(dep_link)) -> None:
     """
     Delete a link.
     """
 
     project = await Controller.instance().get_loaded_project(str(project_id))
     await project.delete_link(link.id)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{link_id}/reset", response_model=schemas.Link)
@@ -170,13 +169,12 @@ async def start_capture(capture_data: dict, link: Link = Depends(dep_link)) -> s
 
 
 @router.post("/{link_id}/capture/stop", status_code=status.HTTP_204_NO_CONTENT)
-async def stop_capture(link: Link = Depends(dep_link)) -> Response:
+async def stop_capture(link: Link = Depends(dep_link)) -> None:
     """
     Stop packet capture on the link.
     """
 
     await link.stop_capture()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{link_id}/capture/stream")

--- a/gns3server/api/routes/controller/nodes.py
+++ b/gns3server/api/routes/controller/nodes.py
@@ -130,44 +130,40 @@ async def get_nodes(project: Project = Depends(dep_project)) -> List[schemas.Nod
 
 
 @router.post("/start", status_code=status.HTTP_204_NO_CONTENT)
-async def start_all_nodes(project: Project = Depends(dep_project)) -> Response:
+async def start_all_nodes(project: Project = Depends(dep_project)) -> None:
     """
     Start all nodes belonging to a given project.
     """
 
     await project.start_all()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/stop", status_code=status.HTTP_204_NO_CONTENT)
-async def stop_all_nodes(project: Project = Depends(dep_project)) -> Response:
+async def stop_all_nodes(project: Project = Depends(dep_project)) -> None:
     """
     Stop all nodes belonging to a given project.
     """
 
     await project.stop_all()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/suspend", status_code=status.HTTP_204_NO_CONTENT)
-async def suspend_all_nodes(project: Project = Depends(dep_project)) -> Response:
+async def suspend_all_nodes(project: Project = Depends(dep_project)) -> None:
     """
     Suspend all nodes belonging to a given project.
     """
 
     await project.suspend_all()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/reload", status_code=status.HTTP_204_NO_CONTENT)
-async def reload_all_nodes(project: Project = Depends(dep_project)) -> Response:
+async def reload_all_nodes(project: Project = Depends(dep_project)) -> None:
     """
     Reload all nodes belonging to a given project.
     """
 
     await project.stop_all()
     await project.start_all()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{node_id}", response_model=schemas.Node)
@@ -201,13 +197,12 @@ async def update_node(node_data: schemas.NodeUpdate, node: Node = Depends(dep_no
     status_code=status.HTTP_204_NO_CONTENT,
     responses={**responses, 409: {"model": schemas.ErrorMessage, "description": "Cannot delete node"}},
 )
-async def delete_node(node_id: UUID, project: Project = Depends(dep_project)) -> Response:
+async def delete_node(node_id: UUID, project: Project = Depends(dep_project)) -> None:
     """
     Delete a node from a project.
     """
 
     await project.delete_node(str(node_id))
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/duplicate", response_model=schemas.Node, status_code=status.HTTP_201_CREATED)
@@ -221,65 +216,59 @@ async def duplicate_node(duplicate_data: schemas.NodeDuplicate, node: Node = Dep
 
 
 @router.post("/{node_id}/start", status_code=status.HTTP_204_NO_CONTENT)
-async def start_node(start_data: dict, node: Node = Depends(dep_node)) -> Response:
+async def start_node(start_data: dict, node: Node = Depends(dep_node)) -> None:
     """
     Start a node.
     """
 
     await node.start(data=start_data)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/stop", status_code=status.HTTP_204_NO_CONTENT)
-async def stop_node(node: Node = Depends(dep_node)) -> Response:
+async def stop_node(node: Node = Depends(dep_node)) -> None:
     """
     Stop a node.
     """
 
     await node.stop()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/suspend", status_code=status.HTTP_204_NO_CONTENT)
-async def suspend_node(node: Node = Depends(dep_node)) -> Response:
+async def suspend_node(node: Node = Depends(dep_node)) -> None:
     """
     Suspend a node.
     """
 
     await node.suspend()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/reload", status_code=status.HTTP_204_NO_CONTENT)
-async def reload_node(node: Node = Depends(dep_node)) -> Response:
+async def reload_node(node: Node = Depends(dep_node)) -> None:
     """
     Reload a node.
     """
 
     await node.reload()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/isolate", status_code=status.HTTP_204_NO_CONTENT)
-async def isolate_node(node: Node = Depends(dep_node)) -> Response:
+async def isolate_node(node: Node = Depends(dep_node)) -> None:
     """
     Isolate a node (suspend all attached links).
     """
 
     for link in node.links:
         await link.update_suspend(True)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/unisolate", status_code=status.HTTP_204_NO_CONTENT)
-async def unisolate_node(node: Node = Depends(dep_node)) -> Response:
+async def unisolate_node(node: Node = Depends(dep_node)) -> None:
     """
     Un-isolate a node (resume all attached suspended links).
     """
 
     for link in node.links:
         await link.update_suspend(False)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{node_id}/links", response_model=List[schemas.Link], response_model_exclude_unset=True)
@@ -321,7 +310,7 @@ async def create_disk_image(
         disk_name: str,
         disk_data: schemas.QemuDiskImageCreate,
         node: Node = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Create a Qemu disk image.
     """
@@ -329,7 +318,6 @@ async def create_disk_image(
     if node.node_type != "qemu":
         raise ControllerBadRequestError("Creating a disk image is only supported on a Qemu node")
     await node.post(f"/disk_image/{disk_name}", data=disk_data.dict(exclude_unset=True))
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.put("/{node_id}/qemu/disk_image/{disk_name}", status_code=status.HTTP_204_NO_CONTENT)
@@ -337,7 +325,7 @@ async def update_disk_image(
         disk_name: str,
         disk_data: schemas.QemuDiskImageUpdate,
         node: Node = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Update a Qemu disk image.
     """
@@ -345,14 +333,13 @@ async def update_disk_image(
     if node.node_type != "qemu":
         raise ControllerBadRequestError("Updating a disk image is only supported on a Qemu node")
     await node.put(f"/disk_image/{disk_name}", data=disk_data.dict(exclude_unset=True))
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.delete("/{node_id}/qemu/disk_image/{disk_name}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_disk_image(
         disk_name: str,
         node: Node = Depends(dep_node)
-) -> Response:
+) -> None:
     """
     Delete a Qemu disk image.
     """
@@ -360,7 +347,6 @@ async def delete_disk_image(
     if node.node_type != "qemu":
         raise ControllerBadRequestError("Deleting a disk image is only supported on a Qemu node")
     await node.delete(f"/disk_image/{disk_name}")
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{node_id}/files/{file_path:path}")
@@ -451,17 +437,15 @@ async def ws_console(websocket: WebSocket, node: Node = Depends(dep_node)) -> No
 
 
 @router.post("/console/reset", status_code=status.HTTP_204_NO_CONTENT)
-async def reset_console_all_nodes(project: Project = Depends(dep_project)) -> Response:
+async def reset_console_all_nodes(project: Project = Depends(dep_project)) -> None:
     """
     Reset console for all nodes belonging to the project.
     """
 
     await project.reset_console_all()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{node_id}/console/reset", status_code=status.HTTP_204_NO_CONTENT)
-async def console_reset(node: Node = Depends(dep_node)) -> Response:
+async def console_reset(node: Node = Depends(dep_node)) -> None:
 
     await node.post("/console/reset")
-    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/gns3server/api/routes/controller/permissions.py
+++ b/gns3server/api/routes/controller/permissions.py
@@ -136,7 +136,7 @@ async def update_permission(
 async def delete_permission(
     permission_id: UUID,
     rbac_repo: RbacRepository = Depends(get_repository(RbacRepository)),
-) -> Response:
+) -> None:
     """
     Delete a permission.
     """
@@ -149,16 +149,13 @@ async def delete_permission(
     if not success:
         raise ControllerNotFoundError(f"Permission '{permission_id}' could not be deleted")
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
-
 
 @router.post("/prune", status_code=status.HTTP_204_NO_CONTENT)
 async def prune_permissions(
         rbac_repo: RbacRepository = Depends(get_repository(RbacRepository))
-) -> Response:
+) -> None:
     """
     Prune orphaned permissions.
     """
 
     await rbac_repo.prune_permissions()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/gns3server/api/routes/controller/projects.py
+++ b/gns3server/api/routes/controller/projects.py
@@ -141,7 +141,7 @@ async def update_project(
 async def delete_project(
         project: Project = Depends(dep_project),
         rbac_repo: RbacRepository = Depends(get_repository(RbacRepository))
-) -> Response:
+) -> None:
     """
     Delete a project.
     """
@@ -150,7 +150,6 @@ async def delete_project(
     await project.delete()
     controller.remove_project(project)
     await rbac_repo.delete_all_permissions_with_path(f"/projects/{project.id}")
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{project_id}/stats")
@@ -167,13 +166,12 @@ def get_project_stats(project: Project = Depends(dep_project)) -> dict:
     status_code=status.HTTP_204_NO_CONTENT,
     responses={**responses, 409: {"model": schemas.ErrorMessage, "description": "Could not close project"}},
 )
-async def close_project(project: Project = Depends(dep_project)) -> Response:
+async def close_project(project: Project = Depends(dep_project)) -> None:
     """
     Close a project.
     """
 
     await project.close()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post(
@@ -420,7 +418,7 @@ async def get_file(file_path: str, project: Project = Depends(dep_project)) -> F
 
 
 @router.post("/{project_id}/files/{file_path:path}", status_code=status.HTTP_204_NO_CONTENT)
-async def write_file(file_path: str, request: Request, project: Project = Depends(dep_project)) -> Response:
+async def write_file(file_path: str, request: Request, project: Project = Depends(dep_project)) -> None:
     """
     Write a file to a project.
     """
@@ -444,8 +442,6 @@ async def write_file(file_path: str, request: Request, project: Project = Depend
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
     except OSError as e:
         raise ControllerError(str(e))
-
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post(

--- a/gns3server/api/routes/controller/roles.py
+++ b/gns3server/api/routes/controller/roles.py
@@ -106,7 +106,7 @@ async def update_role(
 async def delete_role(
     role_id: UUID,
     rbac_repo: RbacRepository = Depends(get_repository(RbacRepository)),
-) -> Response:
+) -> None:
     """
     Delete a role.
     """
@@ -121,8 +121,6 @@ async def delete_role(
     success = await rbac_repo.delete_role(role_id)
     if not success:
         raise ControllerError(f"Role '{role_id}' could not be deleted")
-
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{role_id}/permissions", response_model=List[schemas.Permission])
@@ -145,7 +143,7 @@ async def add_permission_to_role(
         role_id: UUID,
         permission_id: UUID,
         rbac_repo: RbacRepository = Depends(get_repository(RbacRepository))
-) -> Response:
+) -> None:
     """
     Add a permission to a role.
     """
@@ -158,8 +156,6 @@ async def add_permission_to_role(
     if not role:
         raise ControllerNotFoundError(f"Role '{role_id}' not found")
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
-
 
 @router.delete(
     "/{role_id}/permissions/{permission_id}",
@@ -169,7 +165,7 @@ async def remove_permission_from_role(
     role_id: UUID,
     permission_id: UUID,
     rbac_repo: RbacRepository = Depends(get_repository(RbacRepository)),
-) -> Response:
+) -> None:
     """
     Remove member from an user group.
     """
@@ -181,5 +177,3 @@ async def remove_permission_from_role(
     role = await rbac_repo.remove_permission_from_role(role_id, permission)
     if not role:
         raise ControllerNotFoundError(f"Role '{role_id}' not found")
-
-    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/gns3server/api/routes/controller/snapshots.py
+++ b/gns3server/api/routes/controller/snapshots.py
@@ -69,13 +69,12 @@ def get_snapshots(project: Project = Depends(dep_project)) -> List[schemas.Snaps
 
 
 @router.delete("/{snapshot_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_snapshot(snapshot_id: UUID, project: Project = Depends(dep_project)) -> Response:
+async def delete_snapshot(snapshot_id: UUID, project: Project = Depends(dep_project)) -> None:
     """
     Delete a snapshot.
     """
 
     await project.delete_snapshot(str(snapshot_id))
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{snapshot_id}/restore", status_code=status.HTTP_201_CREATED, response_model=schemas.Project)

--- a/gns3server/api/routes/controller/symbols.py
+++ b/gns3server/api/routes/controller/symbols.py
@@ -95,7 +95,7 @@ def get_default_symbols() -> dict:
     dependencies=[Depends(get_current_active_user)],
     status_code=status.HTTP_204_NO_CONTENT
 )
-async def upload_symbol(symbol_id: str, request: Request) -> Response:
+async def upload_symbol(symbol_id: str, request: Request) -> None:
     """
     Upload a symbol file.
     """
@@ -112,4 +112,3 @@ async def upload_symbol(symbol_id: str, request: Request) -> Response:
     # Reset the symbol list
     controller.symbols.list()
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/gns3server/api/routes/controller/templates.py
+++ b/gns3server/api/routes/controller/templates.py
@@ -102,7 +102,7 @@ async def delete_template(
         templates_repo: TemplatesRepository = Depends(get_repository(TemplatesRepository)),
         images_repo: RbacRepository = Depends(get_repository(ImagesRepository)),
         rbac_repo: RbacRepository = Depends(get_repository(RbacRepository))
-) -> Response:
+) -> None:
     """
     Delete a template.
     """
@@ -111,7 +111,6 @@ async def delete_template(
     await rbac_repo.delete_all_permissions_with_path(f"/templates/{template_id}")
     if prune_images:
         await images_repo.prune_images()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("", response_model=List[schemas.Template], response_model_exclude_unset=True)

--- a/gns3server/api/routes/controller/users.py
+++ b/gns3server/api/routes/controller/users.py
@@ -194,7 +194,7 @@ async def update_user(
 async def delete_user(
     user_id: UUID,
     users_repo: UsersRepository = Depends(get_repository(UsersRepository)),
-) -> Response:
+) -> None:
     """
     Delete an user.
     """
@@ -209,8 +209,6 @@ async def delete_user(
     success = await users_repo.delete_user(user_id)
     if not success:
         raise ControllerError(f"User '{user_id}' could not be deleted")
-
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get(
@@ -254,7 +252,7 @@ async def add_permission_to_user(
         user_id: UUID,
         permission_id: UUID,
         rbac_repo: RbacRepository = Depends(get_repository(RbacRepository))
-) -> Response:
+) -> None:
     """
     Add a permission to an user.
     """
@@ -267,8 +265,6 @@ async def add_permission_to_user(
     if not user:
         raise ControllerNotFoundError(f"User '{user_id}' not found")
 
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
-
 
 @router.delete(
     "/{user_id}/permissions/{permission_id}",
@@ -279,7 +275,7 @@ async def remove_permission_from_user(
     user_id: UUID,
     permission_id: UUID,
     rbac_repo: RbacRepository = Depends(get_repository(RbacRepository)),
-) -> Response:
+) -> None:
     """
     Remove permission from an user.
     """
@@ -291,5 +287,3 @@ async def remove_permission_from_user(
     user = await rbac_repo.remove_permission_from_user(user_id, permission)
     if not user:
         raise ControllerNotFoundError(f"User '{user_id}' not found")
-
-    return Response(status_code=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Thanks to aiohttp 0.79.0 we no longer have to explicitly return Response object when an endpoint does not return any content (HTTP status code 204)