### PR TITLE
Update gns3.service.systemd

### DIFF
--- a/init/gns3.service.systemd
+++ b/init/gns3.service.systemd
@@ -6,7 +6,7 @@ After=network.target network-online.target
 [Service]
 User=gns3
 Group=gns3
-ExecStart=/usr/bin/gns3server
+ExecStart=/usr/local/bin/gns3server
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
In reference to bug #1918, the gns3.service.systemd file references ExecPath /usr/bin/gns3server which needs to be changed to /usr/local/bin/gns3server for the daemon/service to run without failure.

Please see the change I made to the service above.