### PR TITLE
Parse name for request to node creation from template

### DIFF
--- a/gns3server/handlers/api/controller/template_handler.py
+++ b/gns3server/handlers/api/controller/template_handler.py
@@ -169,7 +169,7 @@ class TemplateHandler:
         node = await project.add_node_from_template(request.match_info["template_id"],
                                                     x=request.json["x"],
                                                     y=request.json["y"],
-                                                    name=request.json.get("name"))
+                                                    name=request.json.get("name")),
                                                     compute_id=request.json.get("compute_id"))
         response.set_status(201)
         response.json(node)

--- a/gns3server/handlers/api/controller/template_handler.py
+++ b/gns3server/handlers/api/controller/template_handler.py
@@ -169,6 +169,7 @@ class TemplateHandler:
         node = await project.add_node_from_template(request.match_info["template_id"],
                                                     x=request.json["x"],
                                                     y=request.json["y"],
+                                                    name=request.json.get("name"))
                                                     compute_id=request.json.get("compute_id"))
         response.set_status(201)
         response.json(node)


### PR DESCRIPTION
According to the documentation the endpoint `/v2/projects/{project_id}/templates/{template_id}` accepts `name` for node in body ([accepted input](https://api.gns3.net/en/latest/api/v2/controller/template/projectsprojectidtemplatestemplateid.html#input)). In handler code this parameter is never parsed.