### PR TITLE
fix: Install modules required for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,16 @@ RUN apt-get install -y vpcs ubridge
 ADD . /server
 WORKDIR /server
 
+RUN pip3 install \
+    multidict \
+    typing_extensions \
+    attrs \
+    yarl \
+    async_timeout \
+    idna_ssl \
+    charset_normalizer \
+    aiosignal
+
 RUN pip3 install --no-cache-dir -r /server/requirements.txt
 
 EXPOSE 3080


### PR DESCRIPTION
It did not start as is when activated in the docker. 
Should I put it in requirements.txt? 🤔