### PR TITLE
API: add endpoint to expose availables privileges to web UI

### DIFF
--- a/gns3server/api/routes/controller/__init__.py
+++ b/gns3server/api/routes/controller/__init__.py
@@ -32,6 +32,7 @@ from . import users
 from . import groups
 from . import roles
 from . import acl
+from . import privileges
 
 from .dependencies.authentication import get_current_active_user
 
@@ -58,6 +59,12 @@ router.include_router(
     roles.router,
     prefix="/access/roles",
     tags=["Roles"]
+)
+
+router.include_router(
+    privileges.router,
+    prefix="/access/privileges",
+    tags=["Privileges"]
 )
 
 router.include_router(

--- a/gns3server/api/routes/controller/privileges.py
+++ b/gns3server/api/routes/controller/privileges.py
@@ -1,0 +1,43 @@
+#
+# Software Name : GNS3 server
+# Version: 3
+# SPDX-FileCopyrightText: Copyright (c) 2023 Orange Business Services
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This software is distributed under the GPL-3.0 or any later version,
+# the text of which is available at https://www.gnu.org/licenses/gpl-3.0.txt
+# or see the "LICENSE" file for more details.
+#
+# Author: Sylvain MATHIEU
+#
+
+
+"""
+API route for privileges
+"""
+from typing import List
+from gns3server.db.repositories.rbac import RbacRepository
+from .dependencies.database import get_repository
+from fastapi import APIRouter, Depends
+import logging
+
+from gns3server import schemas
+
+log = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.get(
+    "",
+    response_model=List[schemas.Privilege],
+)
+async def get_privileges(
+        rbac_repo: RbacRepository = Depends(get_repository(RbacRepository))
+) -> List[schemas.Privilege]:
+    """
+    Get all privileges.
+
+    Required privilege: None
+    """
+
+    return await rbac_repo.get_privileges()

--- a/tests/api/routes/controller/test_privileges.py
+++ b/tests/api/routes/controller/test_privileges.py
@@ -1,0 +1,25 @@
+#
+# Software Name : GNS3 server
+# Version: 3
+# SPDX-FileCopyrightText: Copyright (c) 2023 Orange Business Services
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This software is distributed under the GPL-3.0 or any later version,
+# the text of which is available at https://www.gnu.org/licenses/gpl-3.0.txt
+# or see the "LICENSE" file for more details.
+#
+# Author: Sylvain MATHIEU
+#
+
+import pytest
+from fastapi import FastAPI, status
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestPrivilegesRoute:
+
+    async def test_get_privileges(self, app: FastAPI, client: AsyncClient) -> None:
+        response = await client.get(app.url_path_for("get_privileges"))
+        assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
Hello,
This PR is about Web UIv3 improvements.
We expose a new Endpoint /v3/access/privileges to get a list of all privileges.
privilege_id is required to update privileges associate to a role.

The endpoint have no privileges control.

Regard
Sylvain121