### PR TITLE
rbac fix: cannot add multiple time same privilege to a role

### DIFF
--- a/gns3server/db/repositories/rbac.py
+++ b/gns3server/db/repositories/rbac.py
@@ -130,6 +130,13 @@ class RbacRepository(BaseRepository):
         if not role_db:
             return None
 
+        """
+         Skip add new privilege if already added for this role.
+        """
+        for p in role_db.privileges:
+            if p.privilege_id == privilege.privilege_id:
+                return role_db
+
         role_db.privileges.append(privilege)
         await self._db_session.commit()
         await self._db_session.refresh(role_db)


### PR DESCRIPTION
On current version of PUT /v3/access/roles/{role_id}/privileges/{privilege_id}, database allow inserting multiple time same privilege for a role.
This generates an error when trying to DELETE the privilege.
This patch silent ignores request if privilege is already applied for the role.
