### PR TITLE
Update a test expression to remove a logical short circuit

### DIFF
--- a/gns3server/controller/node.py
+++ b/gns3server/controller/node.py
@@ -485,7 +485,7 @@ class Node:
 
         # None properties are not be send. Because it can mean the emulator doesn't support it
         for key in list(data.keys()):
-            if data[key] is None or data[key] is {} or key in self.CONTROLLER_ONLY_PROPERTIES:
+            if data[key] is None or data[key] == {} or key in self.CONTROLLER_ONLY_PROPERTIES:
                 del data[key]
 
         return data


### PR DESCRIPTION
In file: node.py, method: `_node_data`, a logical expression uses the identity operator. A new object is created inside the identity check operation and then used for matching identity. Since this is a distinct, new object, it will not have identity and will match with anything else. As a result, the identity check will have a logical short circuit and the program may have unintended behavior. 

The following binary operation

           data[key] is {}

compares a newly created object with the identity operator which will always evaluate to False.

I suggested that the logical operation should be reviewed for correctness. 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.