### PR TITLE
Drop Pyhton 3.7 support (end-of-life)

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
-pytest==7.4.0
-flake8==5.0.4  # v5.0.4 is the last to support Python 3.7
-pytest-timeout==2.1.0
+pytest==7.4.2
+flake8==6.1.0
+pytest-timeout==2.2.0
 pytest-asyncio==0.21.1
 requests==2.31.0
-httpx==0.24.1
+httpx==0.25.0

--- a/gns3server/server.py
+++ b/gns3server/server.py
@@ -267,9 +267,9 @@ class Server:
         else:
             log.info(f"Compute authentication is enabled with username '{config.Server.compute_username}'")
 
-        # we only support Python 3 version >= 3.7
-        if sys.version_info < (3, 7, 0):
-            raise SystemExit("Python 3.7 or higher is required")
+        # we only support Python 3 version >= 3.8
+        if sys.version_info < (3, 8, 0):
+            raise SystemExit("Python 3.8 or higher is required")
 
         log.info(
             "Running with Python {major}.{minor}.{micro} and has PID {pid}".format(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
   { name = "Jeremy Grossmann", email = "developers@gns3.com" }
 ]
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",
@@ -21,7 +21,6 @@ classifiers = [
         "Natural Language :: English",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-uvicorn==0.22.0  # v0.22.0 is the last to support Python 3.7
-fastapi==0.103.2
+uvicorn==0.23.2
+fastapi==0.104.0
 python-multipart==0.0.6
-websockets==11.0.3
+websockets==12.0
 aiohttp==3.8.6,<3.9
 async-timeout==4.0.3
 aiofiles==23.2.1
@@ -16,7 +16,7 @@ alembic==1.12.0
 passlib[bcrypt]==1.7.4
 python-jose==3.3.0
 email-validator==2.0.0.post2
-watchfiles==0.20.0  # v0.20.0 is the last to support Python 3.7
+watchfiles==0.21.0
 zstandard==0.21.0
 platformdirs==3.11.0
 importlib-resources>=1.3; python_version <= '3.9'


### PR DESCRIPTION
Python 3.7 is end-of-life and it is starting to be challending to support it because many of the latest dependency versions already don't.

https://endoflife.date/python
https://devguide.python.org/versions/