### PR TITLE
Update remote-install.sh

### DIFF
--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -163,9 +163,9 @@ log "Install GNS3 packages"
 apt-get install -y gns3-server
 
 log "Create user GNS3 with /opt/gns3 as home directory"
-if [ ! -d "/opt/gns3/" ]
+if [ ! -d "/opt/gns3" ]
 then
-  useradd -m -d /opt/gns3/ gns3
+  useradd -m -d /opt/gns3 gns3
 fi
 
 


### PR DESCRIPTION
Removed an extra slash at the end when setting the user home directory. This was causing unexpected behavior for other scrips as ~ was aliased to /opt/gns3/ instead of the expected  /opt/gns3.

This caused an extra / to appear in commands unexpectedly.