### PR TITLE
[Fix] an issue where the shell option in dialog failed to drop you back to bash.

### DIFF
--- a/scripts/welcome.py
+++ b/scripts/welcome.py
@@ -438,7 +438,8 @@ Images and projects are located in /opt/gns3
                 self.display.clear()
                 if code == Dialog.OK:
                     if tag == "Shell":
-                        os.execvp("bash", ['/bin/bash'])
+                        print("Type: 'welcome.py' to get back to the dialog menu.")
+                        sys.exit(0)
                     elif tag == "Version":
                         self.mode()
                     elif tag == "Restore":


### PR DESCRIPTION
Fixed an issue where the shell option in dialog failed to drop you back to bash.

This commit will cause this version of the welcome.py dialog to differ from the one included with the GNS3 VM found [here](https://github.com/GNS3/gns3-vm/blob/master/scripts/welcome.py)

While very usable there are numerous bugs the with welcome.py dialog when installed via remote-install.sh.

If having this version of welcome.py differ from the [VM version](https://github.com/GNS3/gns3-vm/blob/master/scripts/welcome.py) is not a concern I can go through and easily clean up most of these issues.