### PR TITLE
Update telnet_server.py

### DIFF
--- a/gns3server/utils/asyncio/telnet_server.py
+++ b/gns3server/utils/asyncio/telnet_server.py
@@ -190,6 +190,11 @@ class AsyncioTelnetServer:
         sock = network_writer.get_extra_info("socket")
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        # 60 sec keep alives, close tcp session after 4 missed
+        # Will keep a firewall from aging out telnet console.
+        writer_sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60)
+        writer_sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 10)
+        writer_sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 4)
         #log.debug("New connection from {}".format(sock.getpeername()))
 
         # Keep track of connected clients


### PR DESCRIPTION
Set tcp keepalive timers to 60 seconds. Seems to default to 2 hours on ubuntu 22. Most firewalls will age out an idle tcp session at 1 hour.

Will not address telnet console failing after a tcp session has failed (TimeoutError).