### PR TITLE
Address the telnet console death bug. 

### DIFF
--- a/gns3server/utils/asyncio/telnet_server.py
+++ b/gns3server/utils/asyncio/telnet_server.py
@@ -297,9 +297,17 @@ class AsyncioTelnetServer:
                     reader_read = await self._get_reader(network_reader)
 
                     # Replicate the output on all clients
-                    for connection in self._connections.values():
-                        connection.writer.write(data)
-                        await connection.writer.drain()
+                    for connection_key in list(self._connections.keys()):
+                        client_info = connection_key.get_extra_info("socket").getpeername()
+                        connection = self._connections[connection_key]
+
+                        try:
+                            connection.writer.write(data)
+                            await asyncio.wait_for(connection.writer.drain(), timeout=10)
+                        except:
+                            log.debug(f"Timeout while sending data to client: {client_info}, closing and removing from connection table.")
+                            connection.close()
+                            del self._connections[connection_key]
 
     async def _read(self, cmd, buffer, location, reader):
         """ Reads next op from the buffer or reader"""


### PR DESCRIPTION
Add wait_for for drain() call with a 5 second timeout. If we're stuck on drain then the buffer isn't getting emptied. 5 seconds after drain() blocks, exception will be thrown and client will be removed from connection table and will no longer be a problem. There will be a pause in console output while in this 5 second wait, after that the console will return to normal. 

When the exception is triggered the follow debug will be logged.

2024-02-03 03:07:15 DEBUG telnet_server.py:309 Timeout while sending data to client: ('REMOTE_IP', REMOTE_PORT), closing and removing from connection table. 

It just dawned on me that peerinfo() is a list so if you want that reformatted it would be easy enough to do. 

Fixes [Issue 2344](https://github.com/GNS3/gns3-server/issues/2344)