### PR TITLE
Websocket server close patch

### DIFF
--- a/gns3server/handlers/api/controller/notification_handler.py
+++ b/gns3server/handlers/api/controller/notification_handler.py
@@ -82,6 +82,11 @@ class NotificationHandler:
             log.info("Client has disconnected from controller WebSocket")
             if not ws.closed:
                 await ws.close()
+            try:
+                # call close to force close ws transport. Unknown root cause as of yet.
+                ws._req.transport.close()
+            except:
+                pass
             request.app['websockets'].discard(ws)
 
         return ws

--- a/gns3server/handlers/api/controller/notification_handler.py
+++ b/gns3server/handlers/api/controller/notification_handler.py
@@ -83,6 +83,7 @@ class NotificationHandler:
             if not ws.closed:
                 await ws.close()
             try:
+                # FIXME - This shouldn't be needed. Maybe need bug opened with aiohttp?
                 # call close to force close ws transport. Unknown root cause as of yet.
                 ws._req.transport.close()
             except:


### PR DESCRIPTION
Force close the tcp socket to the client.

This isn't the correct fix but I can't wrap my head around where the issue is, but this will band-aid the issue.

Root cause is still unknown. I did try upgrading aiohttp to 3.9.3 (currently GNS3 seems to use 3.9.1).

