### PR TITLE
New path settings for the server config

### DIFF
--- a/conf/gns3_server.conf
+++ b/conf/gns3_server.conf
@@ -9,17 +9,22 @@ ssl = False
 certfile=/home/gns3/.config/GNS3/ssl/server.cert
 certkey=/home/gns3/.config/GNS3/ssl/server.key
 
-; Path where devices images are stored
+; Path where binary images are stored
 images_path = /home/gns3/GNS3/images
 
 ; Path where user projects are stored
 projects_path = /home/gns3/GNS3/projects
 
-; Path where user appliances are stored
+; Path where custom user appliances are stored
 appliances_path = /home/gns3/GNS3/appliances
 
-; Path where custom device symbols are stored
+; Path where custom user symbols are stored
 symbols_path = /home/gns3/GNS3/symbols
+
+; Path where files like built-in appliances and Docker resources are stored
+; The default path is the local user data directory
+; (Linux: "~/.local/share/GNS3", macOS: "~/Library/Application Support/GNS3", Windows: "%APPDATA%\GNS3")
+; resources_path = /home/gns3/GNS3/resources
 
 ; Option to automatically send crash reports to the GNS3 team
 report_errors = True
@@ -61,6 +66,9 @@ default_nat_interface = vmnet10
 
 ; Enable the built-in templates
 enable_builtin_templates = True
+
+; Install built-in appliances
+install_builtin_appliances = True
 
 ; check if hardware virtualization is used by other emulators (KVM, VMware or VirtualBox)
 hardware_virtualization_check = True

--- a/gns3server/compute/docker/__init__.py
+++ b/gns3server/compute/docker/__init__.py
@@ -29,6 +29,7 @@ import shutil
 import platformdirs
 
 from gns3server.utils import parse_version
+from gns3server.config import Config
 from gns3server.utils.asyncio import locking
 from gns3server.compute.base_manager import BaseManager
 from gns3server.compute.docker.docker_vm import DockerVM
@@ -96,8 +97,10 @@ class Docker(BaseManager):
         Get the Docker resources storage directory
         """
 
+        server_config = Config.instance().get_section_config("Server")
         appname = vendor = "GNS3"
-        docker_resources_dir = os.path.join(platformdirs.user_data_dir(appname, vendor, roaming=True), "docker", "resources")
+        resources_path = os.path.expanduser(server_config.get("resources_path", platformdirs.user_data_dir(appname, vendor, roaming=True)))
+        docker_resources_dir = os.path.join(resources_path, "docker")
         os.makedirs(docker_resources_dir, exist_ok=True)
         return docker_resources_dir
 

--- a/gns3server/controller/__init__.py
+++ b/gns3server/controller/__init__.py
@@ -248,13 +248,19 @@ class Controller:
         if "iou_license" in controller_settings:
             self._iou_license_settings = controller_settings["iou_license"]
 
-        previous_version = controller_settings.get("version")
-        log.info("Comparing controller version {} with config version {}".format(__version__, previous_version))
-        if not previous_version or \
-                parse_version(__version__.split("+")[0]) > parse_version(previous_version.split("+")[0]):
-            self._appliance_manager.install_builtin_appliances()
-        elif not os.listdir(self._appliance_manager.builtin_appliances_path()):
-            self._appliance_manager.install_builtin_appliances()
+        # install the built-in appliances if needed
+        server_config = Config.instance().get_section_config("Server")
+        if server_config.getboolean("install_builtin_appliances", True):
+            previous_version = controller_settings.get("version")
+            log.info("Comparing controller version {} with config version {}".format(__version__, previous_version))
+            builtin_appliances_path = self._appliance_manager.builtin_appliances_path()
+            if not previous_version or \
+                    parse_version(__version__.split("+")[0]) > parse_version(previous_version.split("+")[0]):
+                self._appliance_manager.install_builtin_appliances()
+            elif not os.listdir(builtin_appliances_path):
+                self._appliance_manager.install_builtin_appliances()
+            else:
+                log.info("Built-in appliances are installed in '{}'".format(builtin_appliances_path))
 
         self._appliance_manager.appliances_etag = controller_settings.get("appliances_etag")
         self._appliance_manager.load_appliances()

--- a/gns3server/controller/appliance_manager.py
+++ b/gns3server/controller/appliance_manager.py
@@ -87,8 +87,10 @@ class ApplianceManager:
         Get the built-in appliance storage directory
         """
 
+        server_config = Config.instance().get_section_config("Server")
         appname = vendor = "GNS3"
-        appliances_dir = os.path.join(platformdirs.user_data_dir(appname, vendor, roaming=True), "appliances")
+        resources_path = os.path.expanduser(server_config.get("resources_path", platformdirs.user_data_dir(appname, vendor, roaming=True)))
+        appliances_dir = os.path.join(resources_path, "appliances")
         if delete_first:
             shutil.rmtree(appliances_dir, ignore_errors=True)
         os.makedirs(appliances_dir, exist_ok=True)


### PR DESCRIPTION
* `install_builtin_appliances` can be configured to prevent the server to install the built-in appliances.
* `resources_path' can be configured to choose to store resources (files that are not meant to be edited) in a given location instead of the default local user directory.