### PR TITLE
Fixed issues with installing on Ubuntu 24.04 via remote-install.sh

### DIFF
--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -322,8 +322,8 @@ EOFI
 NEEDRESTART_MODE=a apt-get install -y net-tools
 NEEDRESTART_MODE=a apt-get install -y python3-pip
 NEEDRESTART_MODE=a apt-get install -y dialog
-pip install --no-input --upgrade pip
-pip install --no-input pythondialog
+pip install --no-input --upgrade pip --break-system-packages
+pip install --no-input pythondialog --break-system-packages
 
 #Pull down welcome script from repo
 curl https://raw.githubusercontent.com/GNS3/gns3-server/master/scripts/welcome.py > /usr/local/bin/welcome.py

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -320,10 +320,8 @@ gns3   ALL = (ALL) NOPASSWD: /usr/bin/apt-get
 gns3   ALL = (ALL) NOPASSWD: /usr/sbin/reboot
 EOFI
 NEEDRESTART_MODE=a apt-get install -y net-tools
-NEEDRESTART_MODE=a apt-get install -y python3-pip
 NEEDRESTART_MODE=a apt-get install -y dialog
-pip install --no-input --upgrade pip --break-system-packages
-pip install --no-input pythondialog --break-system-packages
+NEEDRESTART_MODE=a apt-get install -y python3-dialog
 
 #Pull down welcome script from repo
 curl https://raw.githubusercontent.com/GNS3/gns3-server/master/scripts/welcome.py > /usr/local/bin/welcome.py


### PR DESCRIPTION
When rebuilding my server I found an issue when the --with-welcome option was used.

Ubuntu has locked down using pip in the global name-space so python3-dialog is now being installed via apt. This also removes the need for upgrading pip which could cause update issues.