### PR TITLE
Check if remote-install.sh is being run as root

### DIFF
--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -38,6 +38,13 @@ function log {
 }
 
 lsb_release -d | grep "LTS" > /dev/null
+
+if [ "$EUID" -ne 0 ]
+then
+  echo "This script must be run as root"
+  exit 1
+fi
+
 if [ $? != 0 ]
 then
   echo "This script can only be run on a Linux Ubuntu LTS release"


### PR DESCRIPTION
Hi! Added four lines to `remote-install.sh` that check if the script is being run as root, as mentioned in the [docs](https://docs.gns3.com/docs/getting-started/installation/remote-server)