### PR TITLE
Update Dockerfile base image to Ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,27 @@
 # Dockerfile for GNS3 server development
 
-FROM ubuntu:18.04
+FROM ubuntu:24.04
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Set the locale
-ENV LANG en_US.UTF-8  
-ENV LANGUAGE en_US:en  
-ENV LC_ALL en_US.UTF-8 
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+
+# this environment is externally managed
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 RUN apt-get update && apt-get install -y software-properties-common
 RUN add-apt-repository ppa:gns3/ppa
 RUN apt-get update && apt-get install -y \
     locales \
     python3-pip \
-    python3-dev \ 
+    python3-dev \
     qemu-system-x86 \
     qemu-kvm \
-    libvirt-bin \
-    x11vnc 
+    libvirt-daemon-system libvirt-clients \
+    x11vnc
 
 RUN locale-gen en_US.UTF-8
 
@@ -32,4 +35,4 @@ RUN pip3 install --no-cache-dir -r /server/requirements.txt
 
 EXPOSE 3080
 
-CMD python3 -m gns3server
+CMD [ "python3", "-m", "gns3server", "--port", "3080"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ RUN pip3 install --no-cache-dir -r /server/requirements.txt
 
 EXPOSE 3080
 
-CMD ["python3", "-m", "gns3server", "--port", "3080"]
+CMD [ "python3", "-m", "gns3server", "--port", "3080" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ RUN pip3 install --no-cache-dir -r /server/requirements.txt
 
 EXPOSE 3080
 
-CMD [ "python3", "-m", "gns3server", "--port", "3080"]
+CMD ["python3", "-m", "gns3server", "--port", "3080"]

--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ For development, you can run the GNS3 server in a container
 bash scripts/docker_dev_server.sh
 ```
 
+#### use Docker Compose
+
+``` {.bash}
+docker compose up -d
+```
+
 ### Run as daemon (Unix only)
 
 You will find init sample scripts for various systems inside the init

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,7 @@
+services:
+  gen3-server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8001:3080"


### PR DESCRIPTION
## Overview
This pull request updates the Dockerfile base image from Ubuntu 18.04 to Ubuntu 24.04. Additionally, it adds a compose.yaml file to enable launching the application using the `docker compose` command.

## Changes
### Dockerfile:
  * Updated the base image from ubuntu:18.04 to ubuntu:24.04.
  * Updated the ENV syntax to the [recommended format ENV](https://docs.docker.com/reference/build-checks/legacy-key-value-format/) key="value". 
  * Updated the CMD syntax to the [recommended JSONArgsRecommended](https://docs.docker.com/reference/build-checks/json-args-recommended/)

### compose.yaml:
  * Configured the file to allow easy startup with docker compose up.

## Note
I have updated the Dockerfile, but have not been able to fully test it.
