### PR TITLE
Update Dockerfile to use Python 3.10 instead of Python 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,21 @@ COPY ./requirements.txt /gns3server/requirements.txt
 RUN DEBIAN_FRONTEND=noninteractive apt install -y \
     locales \
     software-properties-common \
-    python3-pip \
-    python3-all \
-    python3-setuptools \
-    python3-dev \
     busybox-static \
     gcc \
     qemu-kvm \
     libvirt-daemon-system
+
+RUN apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev libsqlite3-dev wget libbz2-dev
+
+RUN wget https://www.python.org/ftp/python/3.10.16/Python-3.10.16.tgz
+RUN tar -xf Python-3.10.16.tgz
+RUN cd Python-3.10.16 && ./configure --enable-optimizations && make -j 4 && make altinstall
+
+RUN wget https://bootstrap.pypa.io/get-pip.py
+RUN python3.10 get-pip.py
+RUN python3.10 -m pip install --upgrade pip
+RUN python3.10 -m pip install --upgrade setuptools
 
 RUN add-apt-repository ppa:gns3/ppa && apt update && DEBIAN_FRONTEND=noninteractive apt install -y \
     vpcs \
@@ -34,4 +41,4 @@ COPY . /gns3server
 RUN mkdir -p ~/.config/GNS3/3.0/
 RUN cp scripts/gns3_server.conf ~/.config/GNS3/3.0/
 
-RUN python3 -m pip install .
+RUN python3.10 -m pip install .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - ./gns3server:/server/
       - /var/run/docker.sock:/var/run/docker.sock
-    command: python3 -m gns3server --local --port 3080
+    command: python3.10 -m gns3server --local --port 3080
     ports:
       - 3080:3080
       - 5000-5100:5000-5100


### PR DESCRIPTION
### Issue
The GNS3 server package requires Python >=3.9, but our Dockerfile was using the default Python 3.8.10 from Ubuntu Focal. This was causing build failures with the error:
```
ERROR: Package 'gns3-server-3.0.5.dev1' requires a different Python: 3.8.10 not in '>=3.9'
```

### Changes
- Removed the installation of system Python packages (`python3-pip`, `python3-all`, etc.)
- Added build steps to compile and install Python 3.10.16 from source
- Set up pip for Python 3.10
- Updated all Python commands to explicitly use Python 3.10

### Benefits
- Resolves the compatibility issue with GNS3 server requirements
- Provides a consistent Python environment across deployments

These changes allow the Docker image to build successfully and run the GNS3 server with the required Python version.