### PR TITLE
Resolve deprecation warnings of regex library

### DIFF
--- a/gns3server/compute/qemu/qemu_vm.py
+++ b/gns3server/compute/qemu/qemu_vm.py
@@ -225,7 +225,7 @@ class QemuVM(BaseNode):
             if qemu_bin == "qemu":
                 self._platform = "i386"
             else:
-                self._platform = re.sub(r'^qemu-system-(\w+).*$', r'\1', qemu_bin, re.IGNORECASE)
+                self._platform = re.sub(r'^qemu-system-(\w+).*$', r'\1', qemu_bin, flags=re.IGNORECASE)
         if self._platform.split(".")[0] not in QEMU_PLATFORMS:
             raise QemuError("Platform {} is unknown".format(self._platform))
         log.info('QEMU VM "{name}" [{id}] has set the QEMU path to {qemu_path}'.format(name=self._name,


### PR DESCRIPTION
# PR Summary
This small PR resolves deprecation warnings of regex library in Python3.13+:
```python
/home/runner/work/gns3-server/gns3-server/gns3server/compute/qemu/qemu_vm.py:228: DeprecationWarning: 'count' is passed as positional argument
```