### PR TITLE
Fixed Connection closed when exporting a running project

### DIFF
--- a/gns3server/api/routes/controller/projects.py
+++ b/gns3server/api/routes/controller/projects.py
@@ -330,6 +330,9 @@ async def export_project(
     Required privilege: Project.Audit
     """
 
+    if project.is_running():
+        raise ControllerError("Project must be stopped in order to export it")
+
     compression_query = compression.lower()
     if compression_query == "zip":
         compression = zipfile.ZIP_DEFLATED


### PR DESCRIPTION
As mentioned in #2567
Code added:
```py
if project.is_running():
        raise ControllerError("Project must be stopped in order to export it")
```
The code is added at the top of the `export_project()` function.

The problem seems to occur in the following part of the code:
```py
async def streamer():
            log.info(f"Exporting project '{project.name}' with '{compression_query}' compression "
                     f"(level {compression_level})")
            with tempfile.TemporaryDirectory(dir=working_dir) as tmpdir:
                with aiozipstream.ZipFile(compression=compression, compresslevel=compression_level) as zstream:
                    await export_controller_project(
                        zstream,
                        project,
                        tmpdir,
                        include_snapshots=include_snapshots,
                        include_images=include_images,
                        keep_compute_ids=keep_compute_ids,
                        reset_mac_addresses=reset_mac_addresses,
                    )
                    async for chunk in zstream:
                        yield chunk

            log.info(f"Project '{project.name}' exported in {time.time() - begin:.4f} seconds")

...

headers = {"CONTENT-DISPOSITION": f'attachment; filename="{project.name}.gns3project"'}
return StreamingResponse(streamer(), media_type="application/gns3project", headers=headers)
```
In this code snippet, the streamer function is asynchronous, so the `return StreamingResponse` line is reached and returned to the client before the `project.is_running()` check is executed. Because of this, multiple errors are raised (`During handling of the above exception, another exception occurred:`, `The above exception was the direct cause of the following exception:`,` RuntimeError: Caught handled exception, but response already started.`), and the connection closes with a 200 OK status code, as the streamer() raised an error, finishing it's chunk by chunk stream, making the program think it has succesfully exported the project.

It would be more efficient and would save server resources to perform checks such as `project.is_running()` before starting the export process. This approach benefits both the server, by avoiding unnecessary resource usage, and the client, by providing a clear error message describing what went wrong.
<img width="443" height="115" alt="image" src="https://github.com/user-attachments/assets/11246cd8-7638-441f-b68a-98fa512f1360" />

Co-Authored-By: @UfiKing