### PR TITLE
Implement tags for nodes and templates

### DIFF
--- a/gns3server/api/routes/controller/nodes.py
+++ b/gns3server/api/routes/controller/nodes.py
@@ -22,10 +22,10 @@ import aiohttp
 import asyncio
 import ipaddress
 
-from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect, Request, Response, status
+from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect, Request, Response, status, Query
 from fastapi.encoders import jsonable_encoder
 from fastapi.routing import APIRoute
-from typing import List, Callable
+from typing import List, Callable, Optional
 from uuid import UUID
 
 from gns3server.controller import Controller
@@ -135,17 +135,50 @@ async def create_node(node_data: schemas.NodeCreate, project: Project = Depends(
     response_model_exclude_unset=True,
     dependencies=[Depends(has_privilege("Node.Audit"))]
 )
-def get_nodes(project: Project = Depends(dep_project)) -> List[schemas.Node]:
+def get_nodes(
+    project: Project = Depends(dep_project),
+    tags: Optional[List[str]] = Query(None, description="Filter by tags (e.g., tags=vendor:cisco&tags=model:7200)")
+) -> List[schemas.Node]:
     """
     Return all nodes belonging to a given project.
 
     Required privilege: Node.Audit
+
+    Query Parameters:
+    - tags: Filter by tags in format "key:value". Multiple tags are ANDed together.
+            Example: ?tags=vendor:cisco&tags=model:7200
     """
 
     if project.status == "closed":
         # allow to retrieve nodes from a closed project
-        return project.nodes.values()
-    return [v.asdict() for v in project.nodes.values()]
+        nodes = list(project.nodes.values())
+    else:
+        nodes = [v.asdict() for v in project.nodes.values()]
+
+    # Filter by tags if provided
+    if tags:
+        filtered_nodes = []
+        for node in nodes:
+            node_dict = node.asdict() if hasattr(node, 'asdict') else node
+            node_tags = node_dict.get("tags") or {}
+            # Check if all tag filters match
+            match = True
+            for tag_filter in tags:
+                if ":" in tag_filter:
+                    key, value = tag_filter.split(":", 1)
+                    if node_tags.get(key) != value:
+                        match = False
+                        break
+                else:
+                    # Check if key exists
+                    if tag_filter not in node_tags:
+                        match = False
+                        break
+            if match:
+                filtered_nodes.append(node)
+        nodes = filtered_nodes
+
+    return nodes
 
 
 @router.post("/start", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(has_privilege("Node.PowerMgmt"))])

--- a/gns3server/api/routes/controller/nodes.py
+++ b/gns3server/api/routes/controller/nodes.py
@@ -137,7 +137,7 @@ async def create_node(node_data: schemas.NodeCreate, project: Project = Depends(
 )
 def get_nodes(
     project: Project = Depends(dep_project),
-    tags: Optional[List[str]] = Query(None, description="Filter by tags (e.g., tags=vendor:cisco&tags=model:7200)")
+    tags: Optional[List[str]] = Query(None, description="Filter by tags (e.g. tags=vendor:cisco&tags=model:7200)")
 ) -> List[schemas.Node]:
     """
     Return all nodes belonging to a given project.
@@ -145,7 +145,7 @@ def get_nodes(
     Required privilege: Node.Audit
 
     Query Parameters:
-    - tags: Filter by tags in format "key:value". Multiple tags are ANDed together.
+    - tags: Filter by tags. Multiple tags are ANDed together.
             Example: ?tags=vendor:cisco&tags=model:7200
     """
 
@@ -155,29 +155,19 @@ def get_nodes(
     else:
         nodes = [v.asdict() for v in project.nodes.values()]
 
-    # Filter by tags if provided
+    # Filter by tags if provided (all filter tags have to match the node tags)
     if tags:
         filtered_nodes = []
         for node in nodes:
-            node_dict = node.asdict() if hasattr(node, 'asdict') else node
-            node_tags = node_dict.get("tags") or {}
-            # Check if all tag filters match
+            node_tags = node.get("tags") or []
             match = True
             for tag_filter in tags:
-                if ":" in tag_filter:
-                    key, value = tag_filter.split(":", 1)
-                    if node_tags.get(key) != value:
-                        match = False
-                        break
-                else:
-                    # Check if key exists
-                    if tag_filter not in node_tags:
-                        match = False
-                        break
+                if tag_filter not in node_tags:
+                    match = False
+                    break
             if match:
                 filtered_nodes.append(node)
-        nodes = filtered_nodes
-
+        return filtered_nodes
     return nodes
 
 

--- a/gns3server/api/routes/controller/templates.py
+++ b/gns3server/api/routes/controller/templates.py
@@ -169,7 +169,6 @@ async def delete_template(
 async def get_templates(
         templates_repo: TemplatesRepository = Depends(get_repository(TemplatesRepository)),
         current_user: schemas.User = Depends(get_current_active_user),
-        rbac_repo: RbacRepository = Depends(get_repository(RbacRepository)),
         tags: Optional[List[str]] = Query(None, description="Filter by tags (e.g. tags=vendor:cisco&tags=model:7200)")
 ) -> List[schemas.Template]:
     """

--- a/gns3server/api/routes/controller/templates.py
+++ b/gns3server/api/routes/controller/templates.py
@@ -88,10 +88,10 @@ async def get_template(
 
     request_etag = request.headers.get("If-None-Match", "")
     template = await TemplatesService(templates_repo).get_template(template_id)
-    data = json.dumps(template)
+    data = json.dumps(template, default=str)
     template_etag = '"' + hashlib.md5(data.encode()).hexdigest() + '"'
     if template_etag == request_etag:
-        raise HTTPException(status_code=status.HTTP_304_NOT_MODIFIED)
+        return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers={"ETag": template_etag})
     else:
         response.headers["ETag"] = template_etag
         return template

--- a/gns3server/api/routes/controller/templates.py
+++ b/gns3server/api/routes/controller/templates.py
@@ -26,7 +26,7 @@ import logging
 
 log = logging.getLogger(__name__)
 
-from fastapi import APIRouter, Request, HTTPException, Depends, Response, status
+from fastapi import APIRouter, Request, HTTPException, Depends, Response, status, Query
 from typing import List, Optional
 from uuid import UUID
 
@@ -169,15 +169,43 @@ async def delete_template(
 async def get_templates(
         templates_repo: TemplatesRepository = Depends(get_repository(TemplatesRepository)),
         current_user: schemas.User = Depends(get_current_active_user),
-        rbac_repo: RbacRepository = Depends(get_repository(RbacRepository))
+        rbac_repo: RbacRepository = Depends(get_repository(RbacRepository)),
+        tags: Optional[List[str]] = Query(None, description="Filter by tags (e.g., tags=vendor:cisco&tags=model:7200)")
 ) -> List[schemas.Template]:
     """
     Return all templates.
 
     Required privilege: Template.Audit
+
+    Query Parameters:
+    - tags: Filter by tags in format "key:value". Multiple tags are ANDed together.
+            Example: ?tags=vendor:cisco&tags=model:7200
     """
 
     templates = await TemplatesService(templates_repo).get_templates()
+
+    # Filter by tags if provided
+    if tags:
+        filtered_templates = []
+        for template in templates:
+            template_tags = template.get("tags") or {}
+            # Check if all tag filters match
+            match = True
+            for tag_filter in tags:
+                if ":" in tag_filter:
+                    key, value = tag_filter.split(":", 1)
+                    if template_tags.get(key) != value:
+                        match = False
+                        break
+                else:
+                    # Check if key exists
+                    if tag_filter not in template_tags:
+                        match = False
+                        break
+            if match:
+                filtered_templates.append(template)
+        templates = filtered_templates
+
     if current_user.is_superadmin:
         return templates
     else:

--- a/gns3server/api/routes/controller/templates.py
+++ b/gns3server/api/routes/controller/templates.py
@@ -170,7 +170,7 @@ async def get_templates(
         templates_repo: TemplatesRepository = Depends(get_repository(TemplatesRepository)),
         current_user: schemas.User = Depends(get_current_active_user),
         rbac_repo: RbacRepository = Depends(get_repository(RbacRepository)),
-        tags: Optional[List[str]] = Query(None, description="Filter by tags (e.g., tags=vendor:cisco&tags=model:7200)")
+        tags: Optional[List[str]] = Query(None, description="Filter by tags (e.g. tags=vendor:cisco&tags=model:7200)")
 ) -> List[schemas.Template]:
     """
     Return all templates.
@@ -178,30 +178,22 @@ async def get_templates(
     Required privilege: Template.Audit
 
     Query Parameters:
-    - tags: Filter by tags in format "key:value". Multiple tags are ANDed together.
+    - tags: Filter by tags. Multiple tags are ANDed together.
             Example: ?tags=vendor:cisco&tags=model:7200
     """
 
     templates = await TemplatesService(templates_repo).get_templates()
 
-    # Filter by tags if provided
+    # Filter by tags if provided (all filter tags have to match the node tags)
     if tags:
         filtered_templates = []
         for template in templates:
-            template_tags = template.get("tags") or {}
-            # Check if all tag filters match
+            template_tags = template.get("tags") or []
             match = True
             for tag_filter in tags:
-                if ":" in tag_filter:
-                    key, value = tag_filter.split(":", 1)
-                    if template_tags.get(key) != value:
-                        match = False
-                        break
-                else:
-                    # Check if key exists
-                    if tag_filter not in template_tags:
-                        match = False
-                        break
+                if tag_filter not in template_tags:
+                    match = False
+                    break
             if match:
                 filtered_templates.append(template)
         templates = filtered_templates

--- a/gns3server/controller/node.py
+++ b/gns3server/controller/node.py
@@ -97,6 +97,7 @@ class Node:
         self._y = 0
         self._z = 1  # default z value is 1
         self._locked = False
+        self._tags = {}
         self._ports = None
         self._symbol = None
         self._custom_adapters = []
@@ -217,6 +218,17 @@ class Node:
     @properties.setter
     def properties(self, val):
         self._properties = val
+
+    @property
+    def tags(self):
+        return self._tags
+
+    @tags.setter
+    def tags(self, val):
+        if isinstance(val, dict):
+            self._tags = val
+        else:
+            self._tags = {}
 
     def _base_config_file_content(self, path):
         if not os.path.isabs(path):
@@ -823,6 +835,7 @@ class Node:
                 "port_segment_size": self._port_segment_size,
                 "first_port_name": self._first_port_name,
                 "custom_adapters": self._custom_adapters,
+                "tags": self._tags,
         }
 
         if topology_dump:

--- a/gns3server/controller/node.py
+++ b/gns3server/controller/node.py
@@ -97,7 +97,7 @@ class Node:
         self._y = 0
         self._z = 1  # default z value is 1
         self._locked = False
-        self._tags = {}
+        self._tags = []
         self._ports = None
         self._symbol = None
         self._custom_adapters = []
@@ -225,10 +225,7 @@ class Node:
 
     @tags.setter
     def tags(self, val):
-        if isinstance(val, dict):
-            self._tags = val
-        else:
-            self._tags = {}
+        self._tags = val
 
     def _base_config_file_content(self, path):
         if not os.path.isabs(path):

--- a/gns3server/db/models/templates.py
+++ b/gns3server/db/models/templates.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from sqlalchemy import Boolean, Column, String, Integer, Float, ForeignKey, PickleType
+from sqlalchemy import Boolean, Column, String, Integer, Float, ForeignKey, PickleType, JSON
 from sqlalchemy.orm import relationship
 
 from .base import BaseTable, generate_uuid, GUID
@@ -36,9 +36,7 @@ class Template(BaseTable):
     builtin = Column(Boolean, default=False)
     usage = Column(String)
     template_type = Column(String)
-    vendor = Column(String)
-    model = Column(String)
-    netmiko_device_type = Column(String)
+    tags = Column(JSON, default='{}')
     compute_id = Column(String)
     images = relationship("Image", secondary=image_template_map, back_populates="templates")
 

--- a/gns3server/db/models/templates.py
+++ b/gns3server/db/models/templates.py
@@ -36,6 +36,9 @@ class Template(BaseTable):
     builtin = Column(Boolean, default=False)
     usage = Column(String)
     template_type = Column(String)
+    vendor = Column(String)
+    model = Column(String)
+    netmiko_device_type = Column(String)
     compute_id = Column(String)
     images = relationship("Image", secondary=image_template_map, back_populates="templates")
 

--- a/gns3server/db/models/templates.py
+++ b/gns3server/db/models/templates.py
@@ -36,7 +36,7 @@ class Template(BaseTable):
     builtin = Column(Boolean, default=False)
     usage = Column(String)
     template_type = Column(String)
-    tags = Column(JSON, default='{}')
+    tags = Column(JSON)
     compute_id = Column(String)
     images = relationship("Image", secondary=image_template_map, back_populates="templates")
 

--- a/gns3server/db_migrations/versions/98083573d011_add_tags_field_to_templates.py
+++ b/gns3server/db_migrations/versions/98083573d011_add_tags_field_to_templates.py
@@ -1,0 +1,26 @@
+"""Add tags field to templates
+
+Revision ID: 98083573d011
+Revises: 9a5292aa4389
+Create Date: 2026-02-23 18:23:59.857607
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '98083573d011'
+down_revision = '9a5292aa4389'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+
+    op.add_column('templates', sa.Column('tags', sa.String()))
+
+
+def downgrade() -> None:
+
+    op.drop_column('templates', 'tags')

--- a/gns3server/schemas/controller/nodes.py
+++ b/gns3server/schemas/controller/nodes.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from pydantic import BaseModel, Field, model_validator
-from typing import List, Optional, Union, Any
+from typing import List, Optional, Union, Any, Dict
 from enum import Enum
 from uuid import UUID, uuid4
 
@@ -133,6 +133,10 @@ class NodeBase(BaseModel):
     port_segment_size: Optional[int] = Field(None, description="Size of the port segment")
     first_port_name: Optional[str] = Field(None, description="Name of the first port")
     custom_adapters: Optional[List[CustomAdapter]] = None
+    tags: Optional[Dict[str, str]] = Field(
+        default_factory=dict,
+        description="User-defined metadata tags inherited from template or custom"
+    )
 
 
 class NodeCreate(NodeBase):

--- a/gns3server/schemas/controller/nodes.py
+++ b/gns3server/schemas/controller/nodes.py
@@ -14,8 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from pydantic import BaseModel, Field, model_validator
-from typing import List, Optional, Union, Any, Dict
+from pydantic import BaseModel, Field
+from typing import List, Optional, Union
 from enum import Enum
 from uuid import UUID, uuid4
 
@@ -128,14 +128,14 @@ class NodeBase(BaseModel):
     z: Optional[int] = 1
     locked: Optional[bool] = Field(False, description="Whether the element locked or not")
     port_name_format: Optional[str] = Field(
-        None, descript_port_name_formation="Formatting for port name {0} will be replace by port number"
+        None, description="Formatting for port name {0} will be replace by port number"
     )
     port_segment_size: Optional[int] = Field(None, description="Size of the port segment")
     first_port_name: Optional[str] = Field(None, description="Name of the first port")
     custom_adapters: Optional[List[CustomAdapter]] = None
-    tags: Optional[Dict[str, str]] = Field(
-        default_factory=dict,
-        description="User-defined metadata tags inherited from template or custom"
+    tags: Optional[List[str]] = Field(
+        default_factory=list,
+        description="User-defined metadata tags (e.g. 'vendor:cisco' or 'model:7200')"
     )
 
 

--- a/gns3server/schemas/controller/templates/__init__.py
+++ b/gns3server/schemas/controller/templates/__init__.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from pydantic import ConfigDict, BaseModel, Field
-from typing import Optional, Union
+from typing import Optional, Union, Dict
 from enum import Enum
 from uuid import UUID
 
@@ -48,9 +48,10 @@ class TemplateBase(BaseModel):
     template_type: Optional[NodeType] = None
     compute_id: Optional[str] = None
     usage: Optional[str] = ""
-    vendor: Optional[str] = Field(None, description="Device vendor (e.g., Cisco, Juniper, Huawei)")
-    model: Optional[str] = Field(None, description="Device model (e.g., ISR4451-X, MX204, NE40E)")
-    netmiko_device_type: Optional[str] = Field(None, description="Netmiko device type for automation (e.g., cisco_ios, juniper_junos, huawei)")
+    tags: Optional[Dict[str, str]] = Field(
+        default_factory=dict,
+        description="User-defined metadata tags as key-value pairs (e.g., {'vendor': 'cisco', 'model': '7200', 'netmiko_device_type': 'cisco_ios'})"
+    )
 
 
 class TemplateCreate(TemplateBase):

--- a/gns3server/schemas/controller/templates/__init__.py
+++ b/gns3server/schemas/controller/templates/__init__.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from pydantic import ConfigDict, BaseModel, Field
-from typing import Optional, Union, Dict
+from typing import Optional, List
 from enum import Enum
 from uuid import UUID
 
@@ -48,9 +48,9 @@ class TemplateBase(BaseModel):
     template_type: Optional[NodeType] = None
     compute_id: Optional[str] = None
     usage: Optional[str] = ""
-    tags: Optional[Dict[str, str]] = Field(
-        default_factory=dict,
-        description="User-defined metadata tags as key-value pairs (e.g., {'vendor': 'cisco', 'model': '7200', 'netmiko_device_type': 'cisco_ios'})"
+    tags: Optional[List[str]] = Field(
+        default_factory=list,
+        description="User-defined metadata tags (e.g. 'vendor:cisco' or 'model:7200')"
     )
 
 

--- a/gns3server/schemas/controller/templates/__init__.py
+++ b/gns3server/schemas/controller/templates/__init__.py
@@ -48,6 +48,9 @@ class TemplateBase(BaseModel):
     template_type: Optional[NodeType] = None
     compute_id: Optional[str] = None
     usage: Optional[str] = ""
+    vendor: Optional[str] = Field(None, description="Device vendor (e.g., Cisco, Juniper, Huawei)")
+    model: Optional[str] = Field(None, description="Device model (e.g., ISR4451-X, MX204, NE40E)")
+    netmiko_device_type: Optional[str] = Field(None, description="Netmiko device type for automation (e.g., cisco_ios, juniper_junos, huawei)")
 
 
 class TemplateCreate(TemplateBase):

--- a/gns3server/services/templates.py
+++ b/gns3server/services/templates.py
@@ -197,7 +197,7 @@ class TemplatesService:
 
         images_to_add_to_template = []
         if template_type == "dynamips":
-            if settings["image"]:
+            if settings.get("image"):
                 image = await self._find_image(settings["image"])
                 if image.image_type != "ios":
                     raise ControllerBadRequestError(
@@ -205,7 +205,7 @@ class TemplatesService:
                     )
                 images_to_add_to_template.append(image)
         elif template_type == "iou":
-            if settings["path"]:
+            if settings.get("path"):
                 image = await self._find_image(settings["path"])
                 if image.image_type != "iou":
                     raise ControllerBadRequestError(

--- a/tests/api/routes/controller/test_nodes.py
+++ b/tests/api/routes/controller/test_nodes.py
@@ -86,7 +86,59 @@ class TestNodeRoutes:
         response = await client.get(app.url_path_for("get_nodes", project_id=project.id))
         assert response.status_code == status.HTTP_200_OK
         assert response.json()[0]["name"] == "test"
-    
+
+
+    @pytest.mark.parametrize(
+        "tags, expected_match",
+        (
+            ([], True),
+            (["tag1"], True),
+            (["tag1", "tag2"], True),
+            (["tag42"], False),
+            (["tag1", "tag3"], False),
+        ),
+    )
+    async def test_list_nodes_with_tags(
+            self,
+            app: FastAPI,
+            client: AsyncClient,
+            project: Project,
+            compute: Compute,
+            tags: list,
+            expected_match: bool
+    ) -> None:
+        response = MagicMock()
+        response.json = {"console": 2048}
+        compute.post = AsyncioMagicMock(return_value=response)
+
+        await client.post(app.url_path_for("create_node", project_id=project.id), json={
+            "name": "test",
+            "node_type": "vpcs",
+            "compute_id": "example.com",
+            "tags": ["tag1", "tag2"],
+            "properties": {
+                "startup_script": "echo test"
+            }
+        })
+
+        await client.post(app.url_path_for("create_node", project_id=project.id), json={
+            "name": "test2",
+            "node_type": "vpcs",
+            "compute_id": "example.com",
+            "tags": ["tag3", "tag4"],
+            "properties": {
+                "startup_script": "echo test"
+            }
+        })
+
+        params = {"tags": tags}
+        response = await client.get(app.url_path_for("get_nodes", project_id=project.id), params=params)
+        assert response.status_code == status.HTTP_200_OK
+        if expected_match:
+            assert len(response.json()) > 0
+        else:
+            assert len(response.json()) == 0
+
     
     async def test_get_node(
             self,
@@ -131,6 +183,7 @@ class TestNodeRoutes:
             "name": "test",
             "node_type": "vpcs",
             "compute_id": "example.com",
+            "tags": ["tag1", "tag2"],
             "properties": {
                     "startup_script": "echo test"
             }
@@ -139,8 +192,9 @@ class TestNodeRoutes:
         assert response.status_code == 200
         assert response.json()["name"] == "test"
         assert "name" not in response.json()["properties"]
-    
-    
+        assert response.json()["tags"] == ["tag1", "tag2"]
+
+
     async def test_start_all_nodes(
             self,
             app: FastAPI,

--- a/tests/api/routes/controller/test_templates.py
+++ b/tests/api/routes/controller/test_templates.py
@@ -41,15 +41,18 @@ class TestTemplateRoutes:
 
     async def test_route_exist(self, app: FastAPI, client: AsyncClient) -> None:
 
-        new_template = {"base_script_file": "vpcs_base_config.txt",
-                        "category": "guest",
-                        "console_auto_start": False,
-                        "console_type": "telnet",
-                        "default_name_format": "PC{0}",
-                        "name": "VPCS_TEST",
-                        "compute_id": "local",
-                        "symbol": ":/symbols/vpcs_guest.svg",
-                        "template_type": "vpcs"}
+        new_template = {
+            "base_script_file": "vpcs_base_config.txt",
+            "category": "guest",
+            "console_auto_start": False,
+            "console_type": "telnet",
+            "default_name_format": "PC{0}",
+            "name": "VPCS_TEST",
+            "compute_id": "local",
+            "symbol": ":/symbols/vpcs_guest.svg",
+            "template_type": "vpcs",
+            "tags": ["tag1", "tag2"]
+        }
 
         response = await client.post(app.url_path_for("create_template"), json=new_template)
         assert response.status_code == status.HTTP_201_CREATED
@@ -60,6 +63,36 @@ class TestTemplateRoutes:
         response = await client.get(app.url_path_for("get_templates"))
         assert response.status_code == status.HTTP_200_OK
         assert len(response.json()) > 0
+
+    @pytest.mark.parametrize(
+        "tags, expected_match",
+        (
+            ([], True),
+            (["tag1"], True),
+            (["tag1", "tag2"], True),
+            (["tag42"], False),
+            (["tag1", "tag3"], False),
+        ),
+    )
+    async def test_template_list_with_tags(
+            self,
+            app: FastAPI,
+            client: AsyncClient,
+            tags: list,
+            expected_match: bool
+    ) -> None:
+
+        params = {"tags": tags}
+        response = await client.get(app.url_path_for("get_templates"), params=params)
+        assert response.status_code == status.HTTP_200_OK
+        if expected_match:
+            if not tags:
+                assert len(response.json()) == 8
+            else:
+                assert response.json()[0]["name"] == "VPCS_TEST"
+                assert len(response.json()) == 1
+        else:
+            assert len(response.json()) == 0
 
     async def test_template_get(self, app: FastAPI, client: AsyncClient) -> None:
 
@@ -105,11 +138,14 @@ class TestTemplateRoutes:
     async def test_template_update(self, app: FastAPI, client: AsyncClient) -> None:
 
         template_id = str(uuid.uuid4())
-        params = {"template_id": template_id,
-                  "name": "VPCS_TEST",
-                  "version": "3.0",
-                  "compute_id": "local",
-                  "template_type": "vpcs"}
+        params = {
+            "template_id": template_id,
+            "name": "VPCS_TEST",
+            "version": "3.0",
+            "compute_id": "local",
+            "template_type": "vpcs",
+            "tags": ["tag1", "tag2"]
+        }
 
         response = await client.post(app.url_path_for("create_template"), json=params)
         assert response.status_code == status.HTTP_201_CREATED
@@ -117,6 +153,7 @@ class TestTemplateRoutes:
         response = await client.get(app.url_path_for("get_template", template_id=template_id))
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["template_id"] == template_id
+        assert response.json()["tags"] == ["tag1", "tag2"]
 
         params = {"name": "VPCS_TEST_RENAMED", "console_auto_start": True}
         response = await client.put(app.url_path_for("update_template", template_id=template_id), json=params)

--- a/tests/controller/test_node.py
+++ b/tests/controller/test_node.py
@@ -139,6 +139,7 @@ def test_json(node, compute):
         "port_name_format": "Ethernet{0}",
         "port_segment_size": 0,
         "first_port_name": None,
+        "tags": [],
         "custom_adapters": [],
         "console_auto_start": False,
         "ports": [
@@ -176,6 +177,7 @@ def test_json(node, compute):
         "port_segment_size": 0,
         "first_port_name": None,
         "custom_adapters": [],
+        "tags": [],
         "console_auto_start": False,
     }
 


### PR DESCRIPTION
  ## Summary

  This PR adds three new optional fields to the device template schema to support AI/LLM integration for network automation using Netmiko.

  ## Changes

  - Schema Updates (gns3server/schemas/controller/templates/__init__.py)
    - Added vendor: Device vendor name (e.g., Cisco, Juniper, Huawei)
    - Added model: Device model identifier (e.g., ISR4451-X, MX204, NE40E)
    - Added netmiko_device_type: Netmiko device type for automation (e.g., cisco_ios, juniper_junos, huawei)
  - Database Model Updates (gns3server/db/models/templates.py)
    - Added corresponding database columns vendor, model, and netmiko_device_type to the templates table
    - All fields are optional (nullable) to maintain backward compatibility

  ## Motivation

  When AI/LLM systems interact with the GNS3 API to automate network device configuration, they need to know which Netmiko device type to use for establishing telnet connections and executing commands. These fields provide a standardized way to store this metadata directly in the template definition.

  ## API Usage Example

  ### Create a template with device metadata
  POST /v3/templates
```JSON
  {
    "name": "Cisco 7200 Router",
    "template_type": "dynamips",
    "platform": "c7200",
    "vendor": "Cisco",
    "model": "7200",
    "netmiko_device_type": "cisco_ios_telnet",
    "image": "c7200-adventerprisek9-mz.124-24.T5.image"
  }
```

  ### Retrieve templates with device metadata
  GET /v3/templates
  Response:
```JSON
  {
    "template_id": "...",
    "name": "Cisco 7200 Router",
    "vendor": "Cisco",
    "model": "7200",
    "netmiko_device_type": "cisco_ios_telnet",
    ...
  }
```

## Common Netmiko Device Types (for Telnet/Console connections):

  - cisco_ios_telnet - Cisco IOS devices
......

 ## Backward Compatibility

  ✅ Fully backward compatible:
  - All three fields are optional with default value None
  - Existing templates without these fields will continue to work
  - No migration required for existing deployments
  - API responses include these fields even if set to null

 ## Testing

  The changes have been tested:
  - ✅ Template creation with new fields
  - ✅ Template update of new fields
  - ✅ Template listing returns new fields
  - ✅ Existing templates continue to work without the new fields
