### PR TITLE
Add 'created_by' field to track project creator

### DIFF
--- a/gns3server/api/routes/controller/projects.py
+++ b/gns3server/api/routes/controller/projects.py
@@ -123,8 +123,7 @@ async def create_project(
 
     controller = Controller.instance()
     project_dict = jsonable_encoder(project_data, exclude_unset=True)
-    if "created_by" not in project_dict:
-        project_dict["created_by"] = current_user.username
+    project_dict["created_by"] = current_user.username
     project = await controller.add_project(**project_dict)
     return project.asdict()
 

--- a/gns3server/api/routes/controller/projects.py
+++ b/gns3server/api/routes/controller/projects.py
@@ -113,6 +113,7 @@ async def get_projects(
 )
 async def create_project(
         project_data: schemas.ProjectCreate,
+        current_user: schemas.User = Depends(get_current_active_user),
 ) -> schemas.Project:
     """
     Create a new project.
@@ -121,7 +122,10 @@ async def create_project(
     """
 
     controller = Controller.instance()
-    project = await controller.add_project(**jsonable_encoder(project_data, exclude_unset=True))
+    project_dict = jsonable_encoder(project_data, exclude_unset=True)
+    if "created_by" not in project_dict:
+        project_dict["created_by"] = current_user.username
+    project = await controller.add_project(**project_dict)
     return project.asdict()
 
 

--- a/gns3server/controller/project.py
+++ b/gns3server/controller/project.py
@@ -97,6 +97,7 @@ class Project:
         show_interface_labels=False,
         variables=None,
         supplier=None,
+        created_by=None,
     ):
 
         self._controller = controller
@@ -117,6 +118,7 @@ class Project:
         self._show_interface_labels = show_interface_labels
         self._variables = variables
         self._supplier = supplier
+        self._created_by = created_by
 
         self._loading = False
         self._closing = False
@@ -379,6 +381,21 @@ class Project:
         Setter for supplier of the project
         """
         self._supplier = supplier
+
+    @property
+    def created_by(self):
+        """
+        Username of the user who created the project
+        :return: str or None
+        """
+        return self._created_by
+
+    @created_by.setter
+    def created_by(self, created_by):
+        """
+        Setter for the username of the user who created the project
+        """
+        self._created_by = created_by
 
     @property
     def auto_start(self):
@@ -1327,6 +1344,7 @@ class Project:
             "show_interface_labels": self._show_interface_labels,
             "supplier": self._supplier,
             "variables": self._variables,
+            "created_by": self._created_by,
         }
 
     def __repr__(self):

--- a/gns3server/controller/topology.py
+++ b/gns3server/controller/topology.py
@@ -87,6 +87,7 @@ def project_to_topology(project):
         "show_interface_labels": project.show_interface_labels,
         "variables": project.variables,
         "supplier": project.supplier,
+        "created_by": project.created_by,
         "topology": {"nodes": [], "links": [], "computes": [], "drawings": []},
         "type": "topology",
         "revision": GNS3_FILE_FORMAT_REVISION,

--- a/gns3server/schemas/controller/projects.py
+++ b/gns3server/schemas/controller/projects.py
@@ -64,7 +64,6 @@ class ProjectBase(BaseModel):
     show_interface_labels: Optional[bool] = Field(None, description="Show interface labels on the drawing area")
     supplier: Optional[Supplier] = Field(None, description="Supplier of the project")
     variables: Optional[List[Variable]] = Field(None, description="Variables required to run the project")
-    created_by: Optional[str] = Field(None, description="Username of the user who created the project")
 
 
 class ProjectCreate(ProjectBase):
@@ -97,6 +96,7 @@ class Project(ProjectBase):
     name: Optional[str] = None
     status: Optional[ProjectStatus] = None
     filename: Optional[str] = None
+    created_by: Optional[str] = Field(None, description="Username of the user who created the project")
 
 
 class ProjectFile(BaseModel):

--- a/gns3server/schemas/controller/projects.py
+++ b/gns3server/schemas/controller/projects.py
@@ -64,6 +64,7 @@ class ProjectBase(BaseModel):
     show_interface_labels: Optional[bool] = Field(None, description="Show interface labels on the drawing area")
     supplier: Optional[Supplier] = Field(None, description="Supplier of the project")
     variables: Optional[List[Variable]] = Field(None, description="Variables required to run the project")
+    created_by: Optional[str] = Field(None, description="Username of the user who created the project")
 
 
 class ProjectCreate(ProjectBase):

--- a/gns3server/schemas/controller/topology.py
+++ b/gns3server/schemas/controller/topology.py
@@ -66,6 +66,7 @@ class Topology(BaseModel):
     show_interface_labels: Optional[bool] = Field(None, description="Show interface labels on the drawing area")
     supplier: Optional[Supplier] = Field(None, description="Supplier of the project")
     variables: Optional[List[Variable]] = Field(None, description="Variables required to run the project")
+    created_by: Optional[str] = Field(None, description="Username of the user who created the project")
 
 
 def main():

--- a/tests/controller/test_project.py
+++ b/tests/controller/test_project.py
@@ -81,8 +81,19 @@ async def test_json():
         "grid_size": 75,
         "drawing_grid_size": 25,
         "supplier": None,
-        "variables": None
+        "variables": None,
+        "created_by": None
     }
+
+
+@pytest.mark.asyncio
+async def test_created_by():
+
+    with patch('gns3server.controller.project.Project.emit_controller_notification'):
+        p = Project(name="Test", created_by="admin")
+
+    assert p.created_by == "admin"
+    assert p.asdict()["created_by"] == "admin"
 
 
 @pytest.mark.asyncio

--- a/tests/controller/test_topology.py
+++ b/tests/controller/test_topology.py
@@ -59,7 +59,8 @@ async def test_project_to_topology_empty(tmpdir):
             "type": "topology",
             "supplier": None,
             "variables": None,
-            "version": __version__
+            "version": __version__,
+            "created_by": None
         }
 
 


### PR DESCRIPTION
I'm building an exam environment with gns3 for my diploma thesis, which required to know who created certain projects for automated role allocation. since that information isn't stored this is the solution i came up with. I'm not sure if other people might have use cases for this but i thought i might contribute it anyway since it seems like useful information.

Please note that this is my first PR ever in a public repo so there's probably some things i missed.

When a project is created via the API, the 'created_by' field is automatically set to the authenticated user's username. This allows identifying who created each project.

Changes:
- Add 'created_by' parameter to Project model (init, property, asdict)
- Add 'created_by' to ProjectBase and Topology pydantic schemas
- Inject current user as 'created_by' in create_project API route
- Persist 'created_by' in .gns3 topology files
- Add test_created_by and update test_json