### PR TITLE
Fix QEMU serial console artifacts by filtering ANSI CPR responses in …

### DIFF
--- a/gns3server/utils/asyncio/telnet_server.py
+++ b/gns3server/utils/asyncio/telnet_server.py
@@ -20,6 +20,7 @@ import socket
 import asyncio
 import asyncio.subprocess
 import struct
+import re
 
 import logging
 log = logging.getLogger(__name__)
@@ -57,6 +58,7 @@ NAWS = 31     # Negotiate About Window Size
 LINEMO = 34     # Line Mode
 
 READ_SIZE = 1024
+CPR_RESPONSE = re.compile(br"\x1b\[[0-9]{1,4}(;[0-9]{1,4})?R")
 
 
 class TelnetConnection(object):
@@ -285,6 +287,11 @@ class AsyncioTelnetServer:
 
                     if IAC in data:
                         data = await self._IAC_parser(data, network_reader, network_writer, connection)
+
+                    # Some terminal clients may send ANSI cursor position reports
+                    # (e.g. ESC[1;80R) when attaching to a serial console. Those
+                    # responses can show up as spurious characters at the shell prompt.
+                    data = CPR_RESPONSE.sub(b"", data)
 
                     if len(data) == 0:
                         continue


### PR DESCRIPTION
Hi

On LiveRaizo, with QEMu VM with serial access. The VM has an auto-login on root.
I use GNS3 2.2

When the QEMU VM has fully booted and I only open the console at that point, I see these characters in the prompt: ;1R;80R;80R;80R

I think I've removed all the VM's specifics without solving the problem.

With Copilot's help, we solved the problem by adding this patch.

I preferred to submit a pull request rather than explain the code modification in an issue.