### PR TITLE
Fixed the path traversal check

### DIFF
--- a/gns3server/api/routes/index.py
+++ b/gns3server/api/routes/index.py
@@ -46,8 +46,8 @@ async def web_ui(file_path: str):
     file_path = os.path.normpath(file_path).strip("/")
     file_path = os.path.join("static", "web-ui", file_path)
 
-    # Raise error if user try to escape
-    if file_path[0] == ".":
+    # Raise error if user tries to escape the web-ui directory
+    if not os.path.normpath(file_path).startswith(os.path.join("static", "web-ui")):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
 
     static = get_resource(file_path)


### PR DESCRIPTION
Implemented a more robust path traversal check.

Also, a little table on why the old check wasn't that good.
| **Input URL path**                  | **After join**                      | **Old check ( [0] == "." )**       | **New check (normpath starts with   static/web-ui )**   |
|-------------------------------------|-------------------------------------|------------------------------------|---------------------------------------------------------|
| `controllers`                         | `static/web-ui/controllers`           | `"s" == "."`  → False ✗ passes       | `static/web-ui/controllers`  → True ✓ passes              |
| `controller/2/projects`               | `static/web-ui/controller/2/projects` | False ✗ passes                     | True ✓ passes                                           |
| `../../etc/passwd`                    | `static/web-ui/../../etc/passwd`      | `"s" == "."` → False ✗ passes (bug!) | normpath →   `etc/passwd`   → False ✓   blocked           |
| `/etc/passwd`  (after normpath+strip) | `static/web-ui/etc/passwd`            | False ✗ passes                     | True ✓ passes (harmless,   `get_resource`  won't find it) |