### PR TITLE
fix(copilot): improve device_type error message with tested types and…

### DIFF
--- a/gns3server/agent/gns3_copilot/utils/get_gns3_device_port.py
+++ b/gns3server/agent/gns3_copilot/utils/get_gns3_device_port.py
@@ -107,9 +107,15 @@ def get_device_ports_from_topology(
             # Return error if device_type not found in tags
             # Using a default would cause command execution errors
             if device_type is None:
+                tested_device_types = (
+                    "cisco_ios_telnet (Netmiko built-in), gns3_huawei_telnet_ce (custom Huawei), "
+                    "gns3_ruijie_telnet (custom Ruijie)"
+                )
                 error_msg = (
                     f"Device '{device_name}': device_type tag not found. "
                     f"Please add 'device_type:<type>' tag to this device in GNS3. "
+                    f"To configure via Web UI: right-click the device -> Configure -> Tags -> add 'device_type:<type>'. "
+                    f"Tested types: {tested_device_types}. "
                     f"Current tags: {tags}"
                 )
                 logger.error(error_msg)


### PR DESCRIPTION
fix(copilot): improve device_type error message with tested types and config instructions

Add tested device types (cisco_ios_telnet, gns3_huawei_telnet_ce, gns3_ruijie_telnet) to the error message and include Web UI configuration path.

Before: 
![2026-03-30_14-12-13](https://github.com/user-attachments/assets/489b61a9-f244-4af2-8150-94356c4211c6)

After:
![2026-03-30_14-39-28](https://github.com/user-attachments/assets/1e330262-f309-4b6d-843b-de350f6414c6)


![2026-03-30_14-39-48](https://github.com/user-attachments/assets/7ff2f8f3-f069-4305-8670-61889681f4eb)
