### PR TITLE
Fix/symbol cors headers

### DIFF
--- a/gns3server/api/routes/controller/symbols.py
+++ b/gns3server/api/routes/controller/symbols.py
@@ -58,8 +58,7 @@ def get_symbols() -> List[dict]:
 @router.get(
     "/{symbol_id:path}/raw",
     responses={404: {"model": schemas.ErrorMessage, "description": "Could not find symbol"}},
-    # FIXME: this is a temporary workaround due to a bug in the web-ui: https://github.com/GNS3/gns3-web-ui/issues/1466
-    # dependencies=[Depends(has_privilege("Symbol.Audit"))]
+    dependencies=[Depends(has_privilege("Symbol.Audit"))]
 )
 async def get_symbol(symbol_id: str, request: Request) -> Response:
     """

--- a/gns3server/api/routes/controller/symbols.py
+++ b/gns3server/api/routes/controller/symbols.py
@@ -61,7 +61,7 @@ def get_symbols() -> List[dict]:
     # FIXME: this is a temporary workaround due to a bug in the web-ui: https://github.com/GNS3/gns3-web-ui/issues/1466
     # dependencies=[Depends(has_privilege("Symbol.Audit"))]
 )
-async def get_symbol(symbol_id: str) -> FileResponse:
+async def get_symbol(symbol_id: str, request: Request) -> Response:
     """
     Download a symbol file.
 
@@ -71,7 +71,12 @@ async def get_symbol(symbol_id: str) -> FileResponse:
     controller = Controller.instance()
     try:
         symbol = controller.symbols.get_path(symbol_id)
-        return FileResponse(symbol)
+        return FileResponse(
+            symbol,
+            headers={
+                "Access-Control-Allow-Origin": request.headers.get("origin", "*"),
+            }
+        )
     except (KeyError, OSError) as e:
         raise ControllerNotFoundError(f"Could not get symbol file: {e}")
 


### PR DESCRIPTION
  ## Summary

  Fixes two issues with the `GET /v3/symbols/{symbol_id}/raw` endpoint:

  1. **CORS headers missing**: `FileResponse` was not including CORS headers, causing cross-origin requests from frontend applications to
  fail with:
     No 'Access-Control-Allow-Origin' header is present on the requested resource

  2. **Authentication disabled**: The endpoint had authentication disabled as a workaround (introduced in commit `1f0ceb6f`), which has now
   been properly fixed by enabling the `Symbol.Audit` privilege requirement.

  ## Changes

  - Add `Access-Control-Allow-Origin` header to symbol file responses based on the request origin
  - Enable `Symbol.Audit` privilege requirement for the symbol raw endpoint
  - Change return type from `FileResponse` to `Response` to support custom headers

  ## Notes

  This PR is not backward compatible and must be merged together with the corresponding web-ui changes. Keep this PR open until both the server and web-ui https://github.com/GNS3/gns3-web-ui/pull/1620 are ready to be merged simultaneously.

