### PR TITLE
Fix telnet console silent-proxy hang on non-ConnectionError exit (#2344)

### DIFF
--- a/gns3server/utils/asyncio/telnet_server.py
+++ b/gns3server/utils/asyncio/telnet_server.py
@@ -223,26 +223,24 @@ class AsyncioTelnetServer:
             # _reader_process pinned to a dead reader, and subsequent client
             # connections would see _get_reader() return None and never
             # receive node output -- the "silent proxy" hang (issue #2344).
-            log.exception("Unexpected error in telnet proxy; cleaning up client connection")
+            log.exception("Unexpected error in telnet proxy; cleaning up client connection...")
         finally:
             async with self._lock:
                 try:
                     network_writer.close()
-                except Exception:
-                    pass
-                if self._reader_process == network_reader:
-                    self._reader_process = None
-                    # Cancel current read from this reader
-                    if self._current_read is not None:
-                        self._current_read.cancel()
-                        self._current_read = None
+                finally:
+                    if self._reader_process == network_reader:
+                        self._reader_process = None
+                        # Cancel current read from this reader
+                        if self._current_read is not None:
+                            self._current_read.cancel()
+                            self._current_read = None
             try:
                 await connection.disconnected()
-            except Exception:
-                pass
-            # pop() instead of del to avoid KeyError if already removed
-            # elsewhere (e.g. by the broadcast loop's timeout handler).
-            self._connections.pop(network_writer, None)
+            finally:
+                # Use pop() to avoid KeyError if connection was already removed
+                # elsewhere (e.g. by the broadcast loop's timeout handler)
+                self._connections.pop(network_writer, None)
 
     async def close(self):
         for writer, connection in self._connections.items():
@@ -334,7 +332,7 @@ class AsyncioTelnetServer:
                         except (OSError, ConnectionError, asyncio.TimeoutError) as e:
                             log.debug(f"Error sending data to client {client_info}: {e}, closing and removing from connection table.")
                             connection.close()
-                            del self._connections[connection_key]
+                            self._connections.pop(connection_key, None)
 
     async def _read(self, cmd, buffer, location, reader):
         """ Reads next op from the buffer or reader"""

--- a/gns3server/utils/asyncio/telnet_server.py
+++ b/gns3server/utils/asyncio/telnet_server.py
@@ -215,18 +215,34 @@ class AsyncioTelnetServer:
             await self._write_intro(network_writer, echo=self._echo, binary=self._binary, naws=self._naws)
             await connection.connected()
             await self._process(network_reader, network_writer, connection)
-        except (ConnectionError, OSError):
+        except (ConnectionError, OSError, asyncio.CancelledError):
+            pass
+        except Exception:
+            # Catch any unexpected exception so the cleanup below still runs.
+            # Without the try/finally, an uncaught exception here would leave
+            # _reader_process pinned to a dead reader, and subsequent client
+            # connections would see _get_reader() return None and never
+            # receive node output -- the "silent proxy" hang (issue #2344).
+            log.exception("Unexpected error in telnet proxy; cleaning up client connection")
+        finally:
             async with self._lock:
-                network_writer.close()
-                # await network_writer.wait_closed()  # this doesn't work in Python 3.6
+                try:
+                    network_writer.close()
+                except Exception:
+                    pass
                 if self._reader_process == network_reader:
                     self._reader_process = None
                     # Cancel current read from this reader
                     if self._current_read is not None:
                         self._current_read.cancel()
-
-            await connection.disconnected()
-            del self._connections[network_writer]
+                        self._current_read = None
+            try:
+                await connection.disconnected()
+            except Exception:
+                pass
+            # pop() instead of del to avoid KeyError if already removed
+            # elsewhere (e.g. by the broadcast loop's timeout handler).
+            self._connections.pop(network_writer, None)
 
     async def close(self):
         for writer, connection in self._connections.items():


### PR DESCRIPTION
## Summary

Fixes #2344 — "Telnet console death issue" — in the 2.2 branch.

`AsyncioTelnetServer.run()` cleanup was guarded by `except (ConnectionError, OSError):`, so exits via `asyncio.CancelledError` or any other exception type skipped the cleanup and left `_reader_process` pinned to a dead reader. Every subsequent client got `_get_reader() = None` → no data flow from the node → the exact silent-proxy symptom the issue describes.

The existing fixes on 2.2 (`763ef241` wait_for on drain; `ffcfa4cc` catch OSError; `#2347`) each addressed a different failure mode of the same symptom, but didn't cover the `CancelledError` path. That's the specific case this PR handles.

## Change

Convert the `except` block to `try/finally` so cleanup always runs regardless of how `_process()` exits:

- Catch `(ConnectionError, OSError, asyncio.CancelledError)` and generic `Exception` (with `log.exception`) so unexpected failures don't swallow cleanup.
- Reset `_current_read = None` after cancellation so `_get_reader()` doesn't hand a dead future to the next reader-process owner.
- Use `dict.pop(..., None)` instead of `del` to avoid `KeyError` races if the broadcast loop's timeout handler already removed the entry.

## Triggering pattern

Orchestration tool opens a console, runs a few `show` commands, closes abruptly (or the parent task is cancelled). If `_process()` was awaiting on `network_read` / `reader_read` at the moment of cancellation, the `CancelledError` propagates through `run()` and bypasses the ConnectionError-only except clause. The proxy continues to `accept()` new connections (listen socket is fine) but never forwards data because `_reader_process` never got reset.

## Validation

Validated against `gns3/gns3-server:latest` (2.2.56.1) running a 10-scenario sequential regression batch against two GNS3 projects (7-node enterprise + 5-node SP-MPLS topology), with snapshot-restore between scenarios.

- **Before this patch:** reliably hung on the 4th sp_v1 scenario and required node-level stop/start or full project restart to recover. All prior batches had to be split into individual-scenario retries.
- **After this patch:** first-ever clean 10-scenario sequential run, 66 min wall clock, zero hangs. Then the same batch runs successfully across container restarts (patch re-applied via entrypoint hook so recreates still get it).

Test harness that triggered the original hang: scripted Python telnet client doing enable + show + disconnect cycles with `asyncio.CancelledError` propagation, repeated across multiple console ports in quick succession.

## Notes

- No test changes because the existing telnet_server test surface is small and this is a cleanup-path-ordering fix that's hard to express as a focused unit test without heavy asyncio mocking. Happy to add one if you'd prefer.
- The 3.0 branch uses telnetlib3 (PR #2645) so this specific code path doesn't apply there.
- `del self._connections[network_writer]` → `self._connections.pop(network_writer, None)` is a defensive tweak motivated by the broadcast loop in `_process()` which can remove entries asynchronously.