### PR TITLE
Fix update-bundled-web-ui script for newer Angular CLI

### DIFF
--- a/scripts/update-bundled-web-ui.sh
+++ b/scripts/update-bundled-web-ui.sh
@@ -92,10 +92,9 @@ cd "$REPO_DIR"
 
 yarn install
 
-# FIXME: remove --build-optimizer=false
-yarn ng build --source-map=false --build-optimizer=false --configuration=production --base-href /static/web-ui/
+yarn ng build --source-map=false --configuration=production --base-href /static/web-ui/
 
-cp -R $REPO_DIR/dist/* "$GNS3SERVER_DIR/gns3server/static/web-ui/"
+cp -R $REPO_DIR/dist/browser/* "$GNS3SERVER_DIR/gns3server/static/web-ui/"
 
 cd "$GNS3SERVER_DIR"
 git add gns3server/static/web-ui/*


### PR DESCRIPTION
## Summary
- Remove deprecated `--build-optimizer=false` flag from `ng build` command (already flagged as FIXME in the script)
- Update copy path from `dist/*` to `dist/browser/*` to match new Angular build output structure

## Test plan
- [ ] Run `./scripts/update-bundled-web-ui.sh` and verify it completes successfully
- [ ] Verify the built web-ui files are correctly copied to `gns3server/static/web-ui/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)