### PR TITLE
docs: add API error response format documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -66,6 +66,9 @@ Aggregated server statistics API (`GET /v3/statistics`) for monitoring dashboard
 ### VNC WebSocket Console (`features/vnc-websocket-console.md`)
 Browser-based VNC console access via WebSocket. The Controller acts as WebSocket-to-WebSocket relay, and Compute bridges WebSocket to TCP for QEMU/Docker VMs. Supports noVNC clients.
 
+### API Error Responses (`features/api-error-responses.md`)
+Unified error response format across all GNS3 API endpoints. Documents HTTP status codes, error types, and client-side error handling patterns.
+
 ### Web Wireshark (`features/web-wireshark-business-process.md`)
 Web-based packet capture analysis using Docker + xpra HTML5 client. Zero-install Wireshark experience directly in the browser, integrated with GNS3 topologies.
 

--- a/docs/features/api-error-responses.md
+++ b/docs/features/api-error-responses.md
@@ -1,0 +1,80 @@
+# API Error Response Format
+
+## Overview
+
+GNS3 Server uses a unified error response format across all API endpoints. All error responses return a JSON object with a `message` field containing the error details.
+
+## Response Format
+
+```json
+{
+  "message": "Error description here"
+}
+```
+
+## Error Types
+
+| Error Type | HTTP Status | Description |
+|------------|-------------|-------------|
+| `ControllerBadRequestError` | 400 | Invalid request parameters (e.g., validation failure) |
+| `ControllerUnauthorizedError` | 401 | Missing or invalid authentication |
+| `ControllerForbiddenError` | 403 | User lacks required privileges |
+| `ControllerNotFoundError` | 404 | Resource not found |
+| `ControllerError` | 409 | General conflict (e.g., duplicate name) |
+| `ControllerTimeoutError` | 408 | Operation timed out |
+| `ComputeConflictError` | 409 | Compute node returned a conflict |
+| `RequestValidationError` | 422 | Pydantic/FastAPI validation error (field missing or type mismatch) |
+| `SQLAlchemyError` | 500 | Database error |
+
+## Error Response Examples
+
+### Template Already Exists (409)
+```json
+{
+  "message": "A template with name 'my-template' already exists"
+}
+```
+
+### Validation Error (422)
+```json
+{
+  "message": "image field is required"
+}
+```
+
+### Permission Denied (403)
+```json
+{
+  "message": "Permission denied (privilege Template.Allocate is required)"
+}
+```
+
+### Invalid Template Type (400)
+```json
+{
+  "message": "JSON schema error received while creating new template: ..."
+}
+```
+
+## Client-Side Error Handling
+
+When handling errors in the GNS3 Web UI or API clients:
+
+```javascript
+// Extract error message from response
+function extractErrorMessage(error) {
+  if (error.error && error.error.message) {
+    return error.error.message;
+  }
+  if (error.message) {
+    return error.message;
+  }
+  return 'Unknown error';
+}
+```
+
+## References
+
+- Exception handlers: `gns3server/api/server.py`
+- Template validation: `gns3server/schemas/controller/templates/`
+- Error classes: `gns3server/controller/controller_error.py`


### PR DESCRIPTION
## Summary

- Document unified error response format (`{"message": "..."}`) across all GNS3 API endpoints
- Add table of error types with HTTP status codes (400, 401, 403, 404, 409, 422, 500)
- Include error response examples for common scenarios (template duplication, validation errors, permission denied)
- Add client-side error handling code snippet for extracting error messages

## Test plan

- [ ] Verify docs/builds correctly
- [ ] Review error type mappings against exception handlers in `gns3server/api/server.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)