### PR TITLE
fix(web-wireshark): add -k flag to curl for HTTPS with self-signed certs

### DIFF
--- a/gns3server/agent/web_wireshark/manager.py
+++ b/gns3server/agent/web_wireshark/manager.py
@@ -888,8 +888,10 @@ class WebWiresharkManager:
             raise RuntimeError("Container has no IP address")
 
         # Start Wireshark in background (fire-and-forget, no waiting)
+        # Use -k for HTTPS to skip certificate validation (for self-signed certs)
+        curl_insecure_flag = "-k" if capture_stream_url.startswith("https://") else ""
         wireshark_cmd = (
-            f"curl -N -H 'Authorization: Bearer {jwt_token}' "
+            f"curl {curl_insecure_flag} -N -H 'Authorization: Bearer {jwt_token}' "
             f"'{capture_stream_url}' | "
             f"wireshark -i - -k --fullscreen -display :{display} &"
         )


### PR DESCRIPTION
## Summary

- Add `-k` flag to curl command when `capture_stream_url` uses HTTPS protocol to skip SSL certificate validation
- This allows Web Wireshark to work with GNS3 servers using self-signed certificates
- HTTP protocol remains unaffected (no `-k` flag added)

## Test plan

- [ ] Test with HTTP GNS3 server
- [ ] Test with HTTPS GNS3 server using self-signed certificate
- [ ] Verify Web Wireshark capture stream works in both cases

**Note: This PR has not been tested yet.**