### PR TITLE
fix(copilot): add verify=False for HTTPS with self-signed certs

### DIFF
--- a/gns3server/agent/gns3_copilot/tools_v2/packet_capture_tools.py
+++ b/gns3server/agent/gns3_copilot/tools_v2/packet_capture_tools.py
@@ -185,11 +185,14 @@ class PacketCaptureTool(BaseTool):
             import requests
 
             headers = {"Authorization": f"Bearer {jwt_token}"}
+            # Use verify=False for HTTPS to skip certificate validation (for self-signed certs)
+            verify_cert = not capture_url.startswith("https://")
             response = requests.get(
                 capture_url,
                 headers=headers,
                 stream=True,
                 timeout=30,
+                verify=verify_cert,
             )
 
             if response.status_code != 200:


### PR DESCRIPTION
## Summary

- Add `verify=False` to `requests.get()` when `capture_url` uses HTTPS protocol to skip SSL certificate validation
- This allows `PacketCaptureTool` to work with GNS3 servers using self-signed certificates
- HTTP protocol remains unaffected (verify=True)

## Test plan

- [ ] Test with HTTP GNS3 server
- [ ] Test with HTTPS GNS3 server using self-signed certificate
- [ ] Verify PacketCaptureTool can download and analyze packets in both cases

**Note: This PR has not been tested yet.**