### PR TITLE
fix: rename wireshark CLI to gns3-wireshark to avoid conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ python3 -m pip install gns3-server[dev]
 
 **Web Wireshark** (Optional):
 ```shell
-pip install gns3-server && gns3-wireshark-setup
+pip install gns3-server && gns3-wireshark
 ```
 Browser-based packet capture analysis using Wireshark in a Docker container.
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ python3 -m pip install gns3-server[dev]
 
 **Web Wireshark** (Optional):
 ```shell
-pip install gns3-server && gns3-wireshark
+pip install gns3-server && gns3server-web-wireshark-setup
 ```
 Browser-based packet capture analysis using Wireshark in a Docker container.
 

--- a/gns3server/agent/web_wireshark/WEB_WIRESHARK.md
+++ b/gns3server/agent/web_wireshark/WEB_WIRESHARK.md
@@ -10,7 +10,7 @@ This document describes how to manage GNS3 Web Wireshark containers using the ma
 Before using Web Wireshark, you need to set up the Docker image:
 
 ```bash
-pip install . && gns3-wireshark-setup
+pip install . && gns3-wireshark
 ```
 
 This will:

--- a/gns3server/agent/web_wireshark/WEB_WIRESHARK.md
+++ b/gns3server/agent/web_wireshark/WEB_WIRESHARK.md
@@ -10,7 +10,7 @@ This document describes how to manage GNS3 Web Wireshark containers using the ma
 Before using Web Wireshark, you need to set up the Docker image:
 
 ```bash
-pip install . && gns3-wireshark
+pip install . && gns3server-web-wireshark-setup
 ```
 
 This will:

--- a/gns3server/agent/web_wireshark/setup_wireshark_image.py
+++ b/gns3server/agent/web_wireshark/setup_wireshark_image.py
@@ -20,7 +20,7 @@
 Setup Web Wireshark Docker image.
 
 This script pulls or builds the gns3/web-wireshark Docker image.
-Run with: pip install gns3server && gns3-wireshark
+Run with: pip install gns3server && gns3server-web-wireshark-setup
 """
 
 import os

--- a/gns3server/agent/web_wireshark/setup_wireshark_image.py
+++ b/gns3server/agent/web_wireshark/setup_wireshark_image.py
@@ -20,7 +20,7 @@
 Setup Web Wireshark Docker image.
 
 This script pulls or builds the gns3/web-wireshark Docker image.
-Run with: pip install gns3server[wireshark] && gns3-wireshark-setup
+Run with: pip install gns3server && gns3-wireshark
 """
 
 import os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ ai-copilot = {file = ['ai-requirements.txt']}
 gns3server = "gns3server.main:main"
 gns3vmnet = "gns3server.utils.vmnet:main"
 gns3server-uninstall-ai-copilot = "gns3server.utils.uninstall_ai_copilot:main"
-wireshark = "gns3server.agent.web_wireshark.setup_wireshark_image:main"
+gns3-wireshark = "gns3server.agent.web_wireshark.setup_wireshark_image:main"
 
 [tool.setuptools]
 packages = ["gns3server"]


### PR DESCRIPTION
## Summary
- Rename the `wireshark` CLI entry point to `gns3-wireshark` in `pyproject.toml`
- Update documentation references in README.md, WEB_WIRESHARK.md, and setup_wireshark_image.py

## Problem
On Arch Linux (and derivatives like CachyOS), the `gns3-server` package installation fails due to a file conflict:

```
gns3-server: /usr/bin/wireshark exists in filesystem (owned by wireshark-qt)
```

The `wireshark` entry point creates a binary at `/usr/bin/wireshark`, which conflicts with the system Wireshark package (`wireshark-qt`).

## Solution
Rename the CLI from `wireshark` to `gns3-wireshark`, following the same naming convention used by other GNS3 CLI tools (`gns3server`, `gns3vmnet`, `gns3server-uninstall-ai-copilot`).

## Changes
- `pyproject.toml`: Changed entry point from `wireshark` to `gns3-wireshark`
- `README.md`: Updated command example
- `gns3server/agent/web_wireshark/WEB_WIRESHARK.md`: Updated command example
- `gns3server/agent/web_wireshark/setup_wireshark_image.py`: Updated docstring

Fixes #2683

🤖 Generated with [Claude Code](https://claude.com/claude-code)