### PR TITLE
docs: replace 'wireshark' with 'gns3server-web-wireshark-setup' in installation commands

### DIFF
--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -103,7 +103,7 @@ source venv/bin/activate
 # For China mainland users, use mirror:
 # pip install -e . -i https://mirrors.aliyun.com/pypi/simple/
 
-pip install -e . && wireshark
+pip install -e . && gns3server-web-wireshark-setup
 pip install -e .[ai-copilot]
 pip install -e .[dev]
 ```

--- a/docs/features/web-wireshark-business-process.md
+++ b/docs/features/web-wireshark-business-process.md
@@ -27,10 +27,10 @@ Before using Web Wireshark, install the GNS3 server and set up the Docker image:
 
 ```bash
 # Development install
-pip install -e . && wireshark
+pip install -e . && gns3server-web-wireshark-setup
 
 # Production install
-pip install gns3-server && wireshark
+pip install gns3-server && gns3server-web-wireshark-setup
 ```
 
 This command will:


### PR DESCRIPTION
## Summary

- Replace `wireshark` CLI with `gns3server-web-wireshark-setup` in documentation installation commands
- The CLI entry point was renamed to avoid conflict with the system wireshark package

## Changes

- `docs/development-setup.md`: Updated installation command
- `docs/features/web-wireshark-business-process.md`: Updated development and production installation commands

## Test plan

- [ ] Verify installation commands work correctly
- [ ] Confirm no other documentation references the old `wireshark` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)