### PR TITLE
fix: improve hostname validation error messages with allowed characters

### DIFF
--- a/gns3server/compute/docker/docker_vm.py
+++ b/gns3server/compute/docker/docker_vm.py
@@ -188,7 +188,7 @@ class DockerVM(BaseNode):
         """
 
         if not is_rfc1123_hostname_valid(new_name):
-            raise DockerError(f"'{new_name}' is an invalid name to rename Docker container '{self._name}'")
+            raise DockerError(f"'{new_name}' is an invalid name to rename Docker container '{self._name}'. Allowed characters: letters (a-z, A-Z), digits (0-9), and hyphens (-). The name cannot start or end with a hyphen.")
         super(DockerVM, DockerVM).name.__set__(self, new_name)
 
     @property

--- a/gns3server/compute/dynamips/nodes/router.py
+++ b/gns3server/compute/dynamips/nodes/router.py
@@ -1682,7 +1682,7 @@ class Router(BaseNode):
         """
 
         if not is_ios_hostname_valid(new_name):
-            raise DynamipsError(f"{new_name} is an invalid name to rename router '{self._name}'")
+            raise DynamipsError(f"{new_name} is an invalid name to rename router '{self._name}'. Allowed characters: letters (a-z, A-Z), digits (0-9), and hyphens (-). The name must start with a letter, end with a letter or digit, and be 63 characters or fewer.")
 
         await self._hypervisor.send(f'vm rename "{self._name}" "{new_name}"')
 

--- a/gns3server/compute/iou/iou_vm.py
+++ b/gns3server/compute/iou/iou_vm.py
@@ -367,7 +367,7 @@ class IOUVM(BaseNode):
         """
 
         if not is_ios_hostname_valid(new_name):
-            raise IOUError(f"'{new_name}' is an invalid name to rename IOU node '{self._name}'")
+            raise IOUError(f"'{new_name}' is an invalid name to rename IOU node '{self._name}'. Allowed characters: letters (a-z, A-Z), digits (0-9), and hyphens (-). The name must start with a letter, end with a letter or digit, and be 63 characters or fewer.")
         if self.startup_config_file:
             content = self.startup_config_content
             content = re.sub(r"hostname .+$", "hostname " + new_name, content, flags=re.MULTILINE)

--- a/gns3server/compute/qemu/qemu_vm.py
+++ b/gns3server/compute/qemu/qemu_vm.py
@@ -197,7 +197,7 @@ class QemuVM(BaseNode):
         """
 
         if not is_rfc1123_hostname_valid(new_name):
-            raise QemuError(f"'{new_name}' is an invalid name to rename Qemu node '{self._name}'")
+            raise QemuError(f"'{new_name}' is an invalid name to rename Qemu node '{self._name}'. Allowed characters: letters (a-z, A-Z), digits (0-9), and hyphens (-). The name cannot start or end with a hyphen.")
         super(QemuVM, QemuVM).name.__set__(self, new_name)
 
     @property


### PR DESCRIPTION
## Summary

When a hostname validation fails, the error message now includes the allowed character set to help users provide valid names.

## Changes

- Updated error messages in Docker, Qemu, Dynamips, and IOU modules to include:
  - Allowed characters: letters (a-z, A-Z), digits (0-9), and hyphens (-)
  - Specific rules for each validation type (RFC 1123 vs IOS hostname)