### PR TITLE
fix: avoid AttributeError when password is not provided in compute update

### DIFF
--- a/gns3server/db/repositories/computes.py
+++ b/gns3server/db/repositories/computes.py
@@ -69,7 +69,8 @@ class ComputesRepository(BaseRepository):
     async def update_compute(self, compute_id: UUID, compute_update: schemas.ComputeUpdate) -> Optional[models.Compute]:
 
         update_values = compute_update.model_dump(exclude_unset=True)
-        update_values["password"] = compute_update.password.get_secret_value()
+        if compute_update.password is not None:
+            update_values["password"] = compute_update.password.get_secret_value()
 
         query = update(models.Compute).\
             where(models.Compute.compute_id == compute_id).\


### PR DESCRIPTION
## Summary
- Fix AttributeError when updating a compute without providing a password field
- When `compute_update.password` is `None`, calling `.get_secret_value()` on it causes a 500 Internal Server Error
- Only set the password in `update_values` when a password is actually provided