### PR TITLE
Fix duplicate template name validation when updating templates

### DIFF
--- a/gns3server/services/templates.py
+++ b/gns3server/services/templates.py
@@ -281,6 +281,14 @@ class TemplatesService:
         if not db_template:
             raise ControllerNotFoundError(f"Template '{template_id}' not found")
 
+        # Check for duplicate name (excluding current template)
+        if template_update.name is not None:
+            existing_template = await self._templates_repo.get_template_by_name_and_version(
+                template_update.name, db_template.version
+            )
+            if existing_template and existing_template.template_id != template_id:
+                raise ControllerError(f"A template with name '{template_update.name}' already exists")
+
         try:
             # validate the update settings
             update_settings = jsonable_encoder(template_update, exclude_unset=True)


### PR DESCRIPTION
## Summary
- Add validation in the `update_template` method to check if a template with the same name already exists before updating
- Prevents users from creating duplicate template names by editing existing templates
- The check excludes the current template being edited to allow updating other properties without changing the name

## Fixes
Fixes gns3/gns3-web-ui#1658