### PR TITLE
fix: handle directory access for static web-ui routes

### DIFF
--- a/gns3server/api/routes/index.py
+++ b/gns3server/api/routes/index.py
@@ -52,7 +52,7 @@ async def web_ui(file_path: str):
 
     static = get_resource(file_path)
 
-    if static is None or not os.path.exists(static):
+    if static is None or not os.path.exists(static) or os.path.isdir(static):
         static = get_resource(os.path.join("static", "web-ui", "index.html"))
 
     if static is None:

--- a/gns3server/api/server.py
+++ b/gns3server/api/server.py
@@ -73,7 +73,7 @@ def get_application() -> FastAPI:
 
     application.include_router(index.router, tags=["Index"])
     application.include_router(controller.router, prefix="/v3")
-    application.mount("/static", StaticFiles(packages=[('gns3server', 'static')]), name="static")
+    application.mount("/static", StaticFiles(packages=[('gns3server', 'static')], html=True), name="static")
     application.mount("/v3/compute", compute_api, name="compute")
 
     return application


### PR DESCRIPTION
## Summary
This PR fixes an issue where accessing `/static/web-ui` without a trailing slash results in a `RuntimeError: File at path ... is not a file.`

## Problem
When users access `http://127.0.0.1:3080/static/web-ui` (without trailing slash):

1. The route `/static/web-ui/{file_path:path}` does not match (Starlette's path regex requires the `/`)
2. The request falls through to the StaticFiles mount
3. StaticFiles tries to serve the directory as a file → RuntimeError

## Solution
- **server.py**: Set `html=True` on StaticFiles mount to automatically redirect directory URLs to trailing slash versions
- **index.py**: Add `os.path.isdir()` check to handle empty `file_path` gracefully

## Changes
- `gns3server/api/server.py`: Add `html=True` parameter to StaticFiles
- `gns3server/api/routes/index.py`: Add directory check to prevent serving directories as files

Fixes #2680