### PR TITLE
Fix: Check compute connection status before project deletion

### DIFF
--- a/gns3server/controller/__init__.py
+++ b/gns3server/controller/__init__.py
@@ -842,7 +842,14 @@ class Controller:
         compute = self.get_compute(compute_id)
         for project in list(self._projects.values()):
             if project.name == "AUTOIDLEPC":
-                await project.delete()
+                try:
+                    await project.delete()
+                except ControllerForbiddenError as e:
+                    # Project couldn't be deleted due to disconnected computes
+                    log.warning(f"Could not delete AUTOIDLEPC project '{project.id}': {e}")
+                except ControllerError as e:
+                    log.warning(f"Error deleting AUTOIDLEPC project '{project.id}': {e}")
+                # Always remove from controller to allow creating a new one
                 self.remove_project(project)
         project = await self.add_project(name="AUTOIDLEPC")
         node = await project.add_node(

--- a/gns3server/controller/__init__.py
+++ b/gns3server/controller/__init__.py
@@ -842,14 +842,7 @@ class Controller:
         compute = self.get_compute(compute_id)
         for project in list(self._projects.values()):
             if project.name == "AUTOIDLEPC":
-                try:
-                    await project.delete()
-                except ControllerForbiddenError as e:
-                    # Project couldn't be deleted due to disconnected computes
-                    log.warning(f"Could not delete AUTOIDLEPC project '{project.id}': {e}")
-                except ControllerError as e:
-                    log.warning(f"Error deleting AUTOIDLEPC project '{project.id}': {e}")
-                # Always remove from controller to allow creating a new one
+                await project.delete()
                 self.remove_project(project)
         project = await self.add_project(name="AUTOIDLEPC")
         node = await project.add_node(

--- a/gns3server/controller/compute.py
+++ b/gns3server/controller/compute.py
@@ -375,6 +375,11 @@ class Compute:
                 log.info(f"Connecting to compute '{self._id}'")
                 response = await self._run_http_query("GET", "/capabilities")
             except ComputeError as e:
+                # Update connection status and notify UI
+                self._connected = False
+                self._last_error = str(e)
+                self._controller.notification.controller_emit("compute.updated", self.asdict())
+
                 if report_failed_connection:
                     raise
                 log.warning(f"Cannot connect to compute '{self._id}': {e}")

--- a/gns3server/controller/project.py
+++ b/gns3server/controller/project.py
@@ -1031,10 +1031,19 @@ class Project:
                 log.warning(f"Conflict while deleting project: {e}")
 
         # Check if all computes used by this project are connected before deletion
+        # We need to check from the topology file because _project_created_on_compute
+        # gets reset during open()
         disconnected_computes = []
-        for compute in self._project_created_on_compute:
-            if not compute.connected:
-                disconnected_computes.append(compute)
+        for compute_id in self._computes:
+            try:
+                compute = self._controller.get_compute(compute_id)
+                if not compute.connected:
+                    disconnected_computes.append(compute)
+            except ControllerError:
+                # Compute doesn't exist anymore, consider it disconnected
+                log.warning(f"Compute '{compute_id}' not found in controller")
+                # We can't add it to disconnected_computes without the compute object
+                pass
 
         if disconnected_computes:
             compute_names = ", ".join([f"'{c.name}'" for c in disconnected_computes])

--- a/gns3server/controller/project.py
+++ b/gns3server/controller/project.py
@@ -1029,6 +1029,20 @@ class Project:
             except ControllerError as e:
                 # ignore missing images or other conflicts when deleting a project
                 log.warning(f"Conflict while deleting project: {e}")
+
+        # Check if all computes used by this project are connected before deletion
+        disconnected_computes = []
+        for compute in self._project_created_on_compute:
+            if not compute.connected:
+                disconnected_computes.append(compute)
+
+        if disconnected_computes:
+            compute_names = ", ".join([f"'{c.name}'" for c in disconnected_computes])
+            raise ControllerForbiddenError(
+                f"Cannot delete project '{self.name}': {len(disconnected_computes)} compute(s) are disconnected: {compute_names}. "
+                f"Please fix the connection or delete the project manually on those computes."
+            )
+
         await self.delete_on_computes()
         await self.close()
 


### PR DESCRIPTION
## Summary
Fixes #2703 - Prevent project deletion when remote compute nodes are unreachable, providing immediate feedback to users instead of waiting for timeouts.

## Problem
When deleting a project that has nodes on remote compute nodes, if any remote compute is unreachable:
- User waits 120+ seconds for each HTTP query timeout
- Multiple retries compound the wait time
- Eventually fails with generic permission error
- No indication of which compute is causing the issue
- Poor user experience with silent waits

## Changes
This PR includes two main fixes:

### 1. Update Compute Connection Status on Failure (`compute.py`)
When a compute connection fails, the system now:
- Sets `self._connected = False`
- Stores error message in `self._last_error`
- Sends `compute.updated` notification to Web UI

**Benefits:**
- Web UI can display real-time connection status
- Users can see which computes are disconnected before attempting operations
- Provides visibility into compute health

### 2. Check Compute Status Before Project Deletion (`project.py`)
Before deleting a project, the system now:
- Checks all computes used by the project (from topology file)
- Verifies each compute is connected
- Immediately rejects deletion if any compute is disconnected
- Provides clear error message indicating which computes are offline

**Benefits:**
- Immediate feedback (no 120-second waits)
- Clear error messages
- Prevents partial deletion and orphaned resources
- Better user experience

## Error Message Example
```
Cannot delete project 'My Project': 1 compute(s) are disconnected: 'http://192.168.100.186:3080'. 
Please fix the connection or delete the project manually on those computes.
```

## Testing
1. Created project with Docker node on remote compute
2. Made remote compute unreachable (stopped service)
3. Attempted to delete project
4. **Before fix:** Waited 120+ seconds with no feedback, then timeout
5. **After fix:** Immediate error message with clear indication of the problem

## Technical Details
- Uses `self._computes` (from topology file) instead of `self._project_created_on_compute` 
- This is necessary because `_project_created_on_compute` gets reset during `project.open()`
- The topology file persists the compute IDs used by the project
- Check happens early in `delete()` method, before any deletion operations

## Related Issues
- Fixes #2703
- Related to #2704 (excessive reconnection attempts)

## Breaking Changes
None. This is a pure bug fix with no API changes.