### PR TITLE
Fix: Improve Docker container deletion error logging

### DIFF
--- a/gns3server/compute/docker/docker_vm.py
+++ b/gns3server/compute/docker/docker_vm.py
@@ -1089,8 +1089,13 @@ class DockerVM(BaseNode):
             # force - 1/True/true or 0/False/false, Kill then remove the container. Default false.
             try:
                 await self.manager.query("DELETE", f"containers/{self._cid}", params={"force": 1, "v": 1})
-            except DockerError:
+            except DockerHttp404Error:
+                # Container already removed (normal case)
                 pass
+            except DockerError as e:
+                # Container deletion failed - log warning but don't block project close
+                # The stale container will be cleaned up when the project is opened again
+                log.warning(f"Failed to delete Docker container '{self.docker_name}': {e}")
             log.info("Docker container '{name}' [{image}] removed".format(name=self._name, image=self._image))
 
             if release_nio_udp_ports:


### PR DESCRIPTION
## Summary
- Improve error logging when Docker container deletion fails during project close
- Distinguish between 404 (container already removed, normal) and other DockerError (deletion failed, needs attention)
- Add comment explaining stale containers will be cleaned up on project open via automatic 409 conflict resolution

## Problem
When closing a Docker node/project, if container deletion fails (due to Docker daemon unavailability, network issues, or container being locked), the error is silently ignored. This leads to stale containers remaining on the system and causing 409 conflicts when reopening projects.

Users have to manually run `docker container prune -f` to clean up stale containers before reopening projects.

## Solution
- Change `except DockerError: pass` to distinguish between 404 and other errors
- Log a warning with container name and error details when deletion fails
- Add explanatory comment about the automatic cleanup mechanism on project open

This improves observability without blocking project close operations. The root cause of stale containers can now be diagnosed from logs.

## Related
This complements the fix in v3.1.0a1 (commit ce90b2b9) which handles 409 conflicts when opening projects by automatically cleaning up stale containers. This PR improves logging at the source (deletion time) for better observability.

Fixes #2708