### PR TITLE
fix: Handle connection errors when stopping node console

### DIFF
--- a/gns3server/compute/base_node.py
+++ b/gns3server/compute/base_node.py
@@ -474,10 +474,18 @@ class BaseNode:
 
         if self._wrap_console_writer:
             self._wrap_console_writer.close()
-            await self._wrap_console_writer.wait_closed()
+            try:
+                await self._wrap_console_writer.wait_closed()
+            except (ConnectionResetError, BrokenPipeError, OSError):
+                # Connection already closed, ignore error
+                pass
         for telnet_proxy_server in self._wrapper_telnet_servers:
             telnet_proxy_server.close()
-            await telnet_proxy_server.wait_closed()
+            try:
+                await telnet_proxy_server.wait_closed()
+            except (ConnectionResetError, BrokenPipeError, OSError):
+                # Connection already closed, ignore error
+                pass
         self._wrapper_telnet_servers = []
 
     async def reset_wrap_console(self):


### PR DESCRIPTION
## Summary

Fixes ConnectionResetError when stopping QEMU nodes.

## Problem

When stopping a QEMU node, a ConnectionResetError was thrown during console cleanup:

```
ConnectionResetError: [Errno 104] Connection reset by peer
  at gns3server/compute/base_node.py:477 in stop_wrap_console
    await self._wrap_console_writer.wait_closed()
```

The QEMU process would exit successfully (return code 0), but the cleanup
process would fail when waiting for the console writer to close, resulting
in a 500 error being returned to the client.

## Root Cause

Race condition where:
1. QEMU process exits and closes connections
2. Console cleanup starts and calls close() on writer
3. Connection is reset by peer before wait_closed() completes
4. Python 3.13 asyncio raises ConnectionResetError

## Solution

Add exception handling in `stop_wrap_console()` to gracefully handle
connection errors during cleanup:

```python
try:
    await self._wrap_console_writer.wait_closed()
except (ConnectionResetError, BrokenPipeError, OSError):
    # Connection already closed, ignore error
    pass
```

## Impact

- Nodes still stop correctly (process exit code 0)
- No more 500 errors during stop operation
- Cleaner logs (no unhandled exceptions)

## Testing

Manual testing with QEMU node:
- ✅ Node stops successfully
- ✅ No 500 error returned
- ✅ No exception in logs