### PR TITLE
fix: Skip offline compute nodes during project import

### DIFF
--- a/gns3server/controller/import_project.py
+++ b/gns3server/controller/import_project.py
@@ -134,9 +134,16 @@ async def import_project(
                     node["compute_id"] = "vm"
         else:
             # Round-robin through available compute resources.
-            compute_nodes = itertools.cycle(controller.computes)
-            for node in topology["topology"]["nodes"]:
-                node["compute_id"] = next(compute_nodes)
+            # Only use computes that are connected to avoid import failures
+            available_computes = {compute_id: compute for compute_id, compute in controller.computes.items() if compute.connected}
+            if available_computes:
+                compute_nodes = itertools.cycle(available_computes)
+                for node in topology["topology"]["nodes"]:
+                    node["compute_id"] = next(compute_nodes)
+            else:
+                # No remote computes are connected, use local only
+                for node in topology["topology"]["nodes"]:
+                    node["compute_id"] = "local"
 
     compute_created = set()
     for node in topology["topology"]["nodes"]:


### PR DESCRIPTION
When importing a project on Linux, the round-robin logic would attempt to distribute nodes across all configured compute resources, including offline ones. This caused import failures when any remote compute was unreachable.

## Problem
Importing a project fails with the error:
```
Cannot connect to compute 'X' with request POST /projects
```

This happens because the round-robin load balancing (added in commit 90e3a8d6, 2017) distributes nodes across **all** configured compute nodes without checking if they are online.

## Solution
Filter the compute list to only include connected computes before round-robin distribution. If no remote computes are connected, all nodes are assigned to the local compute.

## Changes
- Modified `import_project.py` to check `compute.connected` before round-robin
- Falls back to local-only assignment when no remote computes are available
- Matches the approach used in `project._get_disconnected_computes()`

## Testing
Import projects successfully even when some compute nodes are offline. Nodes are distributed only across connected compute resources.