### PR TITLE
fix: remove explicit paramiko pin to resolve dependency conflict with netmiko

### DIFF
--- a/ai-requirements.txt
+++ b/ai-requirements.txt
@@ -31,7 +31,6 @@ langsmith>=0.7.7
 
 # Network Automation
 netmiko>=4.7.0
-paramiko>=5.0.0
 nornir>=3.5.0
 nornir-netmiko>=1.0.1
 nornir-utils>=0.2.0


### PR DESCRIPTION
paramiko>=5.0.0 conflicts with netmiko 4.7.0 which requires paramiko<5.0, causing pip to fail with `ResolutionImpossible`.

Removing the explicit pin; paramiko is pulled in transitively via netmiko. To fix CVE-2026-44405, users can upgrade paramiko separately:

```
pip install "paramiko>=5.0.0"
```