### PR TITLE
feat: add show_filters_icon property to Link for controlling Web UI filter icon display

### DIFF
--- a/gns3server/api/routes/controller/links.py
+++ b/gns3server/api/routes/controller/links.py
@@ -107,6 +107,8 @@ async def create_link(project_id: UUID, link_data: schemas.LinkCreate) -> schema
         await link.update_link_style(link_data["link_style"])
     if "suspend" in link_data:
         await link.update_suspend(link_data["suspend"])
+    if "show_filters_icon" in link_data:
+        await link.update_show_filters_icon(link_data["show_filters_icon"])
     try:
         for node in link_data["nodes"]:
             await link.add_node(
@@ -171,6 +173,8 @@ async def update_link(link_data: schemas.LinkUpdate, link: Link = Depends(dep_li
         await link.update_link_style(link_data["link_style"])
     if "suspend" in link_data:
         await link.update_suspend(link_data["suspend"])
+    if "show_filters_icon" in link_data:
+        await link.update_show_filters_icon(link_data["show_filters_icon"])
     if "nodes" in link_data:
         await link.update_nodes(link_data["nodes"])
     return link.asdict()

--- a/gns3server/controller/link.py
+++ b/gns3server/controller/link.py
@@ -574,7 +574,7 @@ class Link:
                 "filters": self._filters,
                 "link_style": self._link_style,
                 "suspend": self._suspended,
-                "show_filters_icon": self._show_filters_icon,
+                "show_filters_icon": getattr(self, '_show_filters_icon', True),
             }
         return {
             "nodes": res,
@@ -589,5 +589,5 @@ class Link:
             "suspend": self._suspended,
             "link_style": self._link_style,
             "wireshark": self._wireshark,
-            "show_filters_icon": self._show_filters_icon,
+            "show_filters_icon": getattr(self, '_show_filters_icon', True),
         }

--- a/gns3server/controller/link.py
+++ b/gns3server/controller/link.py
@@ -103,7 +103,7 @@ class Link:
         """
         Get whether to show filters icon in Web UI
         """
-        return self._show_filters_icon
+        return getattr(self, '_show_filters_icon', True)
 
     @property
     def project(self):

--- a/gns3server/controller/link.py
+++ b/gns3server/controller/link.py
@@ -89,6 +89,7 @@ class Link:
         self._filters = {}
         self._link_style = {}
         self._wireshark = False
+        self._show_filters_icon = True
 
     @property
     def filters(self):
@@ -96,6 +97,13 @@ class Link:
         Get an array of filters
         """
         return self._filters
+
+    @property
+    def show_filters_icon(self):
+        """
+        Get whether to show filters icon in Web UI
+        """
+        return self._show_filters_icon
 
     @property
     def project(self):
@@ -164,6 +172,17 @@ class Link:
         if value != self._suspended:
             self._suspended = value
             await self.update()
+            self._project.emit_notification("link.updated", self.asdict())
+            self._project.dump()
+
+    async def update_show_filters_icon(self, value):
+        """
+        Update the show_filters_icon property.
+
+        :param value: Boolean indicating whether to show filters icon in Web UI
+        """
+        if value != self._show_filters_icon:
+            self._show_filters_icon = value
             self._project.emit_notification("link.updated", self.asdict())
             self._project.dump()
 
@@ -555,6 +574,7 @@ class Link:
                 "filters": self._filters,
                 "link_style": self._link_style,
                 "suspend": self._suspended,
+                "show_filters_icon": self._show_filters_icon,
             }
         return {
             "nodes": res,
@@ -569,4 +589,5 @@ class Link:
             "suspend": self._suspended,
             "link_style": self._link_style,
             "wireshark": self._wireshark,
+            "show_filters_icon": self._show_filters_icon,
         }

--- a/gns3server/controller/project.py
+++ b/gns3server/controller/project.py
@@ -1208,6 +1208,8 @@ class Project:
                     await link.update_filters(link_data["filters"])
                 if "link_style" in link_data:
                     await link.update_link_style(link_data["link_style"])
+                if "show_filters_icon" in link_data:
+                    await link.update_show_filters_icon(link_data["show_filters_icon"])
                 for node_link in link_data.get("nodes", []):
                     node = self.get_node(node_link["node_id"])
                     port = node.get_port(node_link["adapter_number"], node_link["port_number"])

--- a/gns3server/schemas/controller/links.py
+++ b/gns3server/schemas/controller/links.py
@@ -62,6 +62,7 @@ class LinkBase(BaseModel):
     suspend: Optional[bool] = None
     link_style: Optional[LinkStyle] = None
     filters: Optional[dict] = None
+    show_filters_icon: Optional[bool] = None
 
 
 class LinkCreate(LinkBase):

--- a/gns3server/schemas/controller/links.py
+++ b/gns3server/schemas/controller/links.py
@@ -62,7 +62,7 @@ class LinkBase(BaseModel):
     suspend: Optional[bool] = None
     link_style: Optional[LinkStyle] = None
     filters: Optional[dict] = None
-    show_filters_icon: Optional[bool] = None
+    show_filters_icon: Optional[bool] = Field(default=True, description="Show filters icon in Web UI")
 
 
 class LinkCreate(LinkBase):

--- a/gns3server/schemas/controller/links.py
+++ b/gns3server/schemas/controller/links.py
@@ -62,7 +62,10 @@ class LinkBase(BaseModel):
     suspend: Optional[bool] = None
     link_style: Optional[LinkStyle] = None
     filters: Optional[dict] = None
-    show_filters_icon: Optional[bool] = Field(default=True, description="Show filters icon in Web UI")
+    show_filters_icon: Optional[bool] = Field(
+        True,
+        description="Show filters icon in Web UI"
+    )
 
 
 class LinkCreate(LinkBase):

--- a/tests/controller/test_link.py
+++ b/tests/controller/test_link.py
@@ -221,6 +221,7 @@ async def test_json(project, compute):
             }
         ],
         "filters": {},
+        "show_filters_icon": True,
         "link_style": {},
         "suspend": False,
         'wireshark': False,
@@ -254,6 +255,7 @@ async def test_json(project, compute):
         ],
         "link_style": {},
         "filters": {},
+        "show_filters_icon": True,
         "suspend": False
     }
 


### PR DESCRIPTION
This commit adds a new `show_filters_icon` property to the Link class, allowing users to control whether filter icons are displayed in the Web UI at the individual link level.

**Purpose:**
This feature enables AI fault injection modules to modify link properties via packet filters while setting `show_filters_icon = false`, keeping the packet filter icon hidden from the user interface. Users can still manually toggle the icon display in the Web UI when needed.

**Changes:**
- Added `_show_filters_icon` attribute to Link class (default: `True`)
- Added `show_filters_icon` property getter with `getattr` fallback for backward compatibility
- Added `update_show_filters_icon()` method following the same pattern as `update_link_style()`
- Updated `asdict()` to include the new field in both topology and regular dumps
- Added `show_filters_icon` field to `LinkBase` schema using `Optional[bool] = Field(True, ...)` pattern (matching the existing `wireshark` field)
- Updated API routes to handle the new field in both create and update operations
- Added loading logic in `project.open()` to restore `show_filters_icon` from topology files when reopening projects

**Why this pattern?**
- UI-only property, does not affect compute nodes (no `await self.update()` call), consistent with `link_style` behavior
- Uses `getattr(self, '_show_filters_icon', True)` to handle edge case where old Link objects may lack this attribute
- Schema Field definition matches the `wireshark` pattern to work correctly with `response_model_exclude_unset=True`

**API Impact:**
- `POST /v3/projects/{project_id}/links` — accepts `show_filters_icon` in request body
- `PUT /v3/projects/{project_id}/links/{link_id}` — can update `show_filters_icon`
- `GET /v3/projects/{project_id}/links/{link_id}` — returns `show_filters_icon` field