### PR TITLE
chore: update GNS3 skills repository to official organization

### DIFF
--- a/docs/gns3-copilot/implemented/fault-injection.md
+++ b/docs/gns3-copilot/implemented/fault-injection.md
@@ -121,7 +121,7 @@ sequenceDiagram
 
 ## Injection Skills Repository
 
-Skills are organized by protocol/category in the external [GNS3-Skills](https://github.com/yueguobin/GNS3-Skills) repository:
+Skills are organized by protocol/category in the external [GNS3-Skills](https://github.com/gns3/gns3-skills) repository:
 
 | Category | File | Example Issues |
 |----------|------|----------------|

--- a/docs/gns3-copilot/implemented/skills-repository.md
+++ b/docs/gns3-copilot/implemented/skills-repository.md
@@ -10,7 +10,7 @@ See LICENSE file for licensing information.
 
 ## Overview
 
-GNS3 Copilot loads all skills, prompts, and security configurations from an external Git repository at [github.com/yueguobin/GNS3-Skills](https://github.com/yueguobin/GNS3-Skills). This enables dynamic updates without server redeployment.
+GNS3 Copilot loads all skills, prompts, and security configurations from an external Git repository at [github.com/gns3/gns3-skills](https://github.com/gns3/gns3-skills). This enables dynamic updates without server redeployment.
 
 The repository provides:
 - **Injection skills** (39 categories): Network fault scenarios for troubleshooting practice
@@ -74,14 +74,14 @@ Skills repository settings are configured in `gns3_server.conf` under the `[Serv
 
 ```ini
 [Server]
-skills_repo_url = https://github.com/yueguobin/GNS3-Skills.git
+skills_repo_url = https://github.com/gns3/gns3-skills.git
 skills_repo_branch = main
 skills_auto_update = true
 ```
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `skills_repo_url` | `https://github.com/yueguobin/GNS3-Skills.git` | Git repository URL |
+| `skills_repo_url` | `https://github.com/gns3/gns3-skills.git` | Git repository URL |
 | `skills_repo_branch` | `main` | Git branch to track |
 | `skills_auto_update` | `true` | Automatically pull on reload |
 

--- a/docs/gns3-copilot/roadmap/skills-editor-api-roadmap.md
+++ b/docs/gns3-copilot/roadmap/skills-editor-api-roadmap.md
@@ -38,7 +38,7 @@ graph TD
 
     subgraph "Remote"
         GH[GitHub API<br/>Pull Requests]
-        REPO[yueguobin/GNS3-Skills]
+        REPO[gns3/gns3-skills]
     end
 
     UI -->|CRUD + PR| API
@@ -147,7 +147,7 @@ All endpoints require **superadmin** authentication. Prefix: `/v3/copilot/skills
     {"category": "config", "file_count": 1, "path": "config/"}
   ],
   "repository": {
-    "repo_url": "https://github.com/yueguobin/GNS3-Skills.git",
+    "repo_url": "https://github.com/gns3/gns3-skills.git",
     "branch": "main",
     "current_version": "abc123def456...",
     "is_dirty": false
@@ -241,7 +241,7 @@ Response:
 ```json
 {
   "success": true,
-  "pr_url": "https://github.com/yueguobin/GNS3-Skills/pull/42",
+  "pr_url": "https://github.com/gns3/gns3-skills/pull/42",
   "pr_number": 42,
   "branch": "fix/ospf-descriptions"
 }

--- a/gns3server/agent/gns3_copilot/configs/skills_config.py
+++ b/gns3server/agent/gns3_copilot/configs/skills_config.py
@@ -34,7 +34,7 @@ from gns3server.config import Config
 # Default skills repository configuration
 SKILLS_CONFIG = {
     # Git repository URL for skills
-    "repo_url": "https://github.com/yueguobin/GNS3-Skills.git",
+    "repo_url": "https://github.com/gns3/gns3-skills.git",
 
     # Git branch to use
     "branch": "main",

--- a/gns3server/agent/gns3_copilot/prompts/__init__.py
+++ b/gns3server/agent/gns3_copilot/prompts/__init__.py
@@ -29,7 +29,7 @@ Prompts Module for GNS3-Copilot
 This package provides system prompts loading utilities for the GNS3-Copilot AI agent.
 
 All system prompts are now loaded from the external GNS3-Skills repository:
-https://github.com/yueguobin/GNS3-Skills
+https://github.com/gns3/gns3-skills
 
 Available prompts (loaded from external repository):
 - lab_automation_assistant.md: Lab automation mode (diagnostics + config)

--- a/gns3server/agent/gns3_copilot/skills/manager.py
+++ b/gns3server/agent/gns3_copilot/skills/manager.py
@@ -76,12 +76,12 @@ class SkillsManager:
         Initialize the skills manager.
 
         Args:
-            repo_url: Git repository URL (default: https://github.com/yueguobin/GNS3-Skills.git)
+            repo_url: Git repository URL (default: https://github.com/gns3/gns3-skills.git)
             branch: Git branch to use (default: "main")
             auto_update: Whether to automatically pull updates on reload
         """
         if repo_url is None:
-            repo_url = "https://github.com/yueguobin/GNS3-Skills.git"
+            repo_url = "https://github.com/gns3/gns3-skills.git"
 
         # Get local path from GNS3 config directory
         config_dir = Config.instance().config_dir

--- a/gns3server/schemas/config.py
+++ b/gns3server/schemas/config.py
@@ -159,7 +159,7 @@ class ServerSettings(BaseModel):
     allow_remote_console: bool = False
     enable_builtin_templates: bool = True
     install_builtin_appliances: bool = True
-    skills_repo_url: str = "https://github.com/yueguobin/GNS3-Skills.git"
+    skills_repo_url: str = "https://github.com/gns3/gns3-skills.git"
     skills_repo_branch: str = "main"
     skills_auto_update: bool = True
     model_config = ConfigDict(validate_assignment=True, str_strip_whitespace=True)


### PR DESCRIPTION
## Summary

Update the default download repository address for GNS3 skills from `yueguobin/GNS3-Skills` to `gns3/gns3-skills` to use the official organization repository.

## Changes

- Updated `skills_repo_url` default in `ServerSettings` schema
- Updated default repository URL in `SkillsManager` class
- Updated `SKILLS_CONFIG` default configuration
- Updated all documentation references to point to the official repository

## Files Modified

- `gns3server/schemas/config.py` - ServerSettings default skills_repo_url
- `gns3server/agent/gns3_copilot/configs/skills_config.py` - SKILLS_CONFIG default
- `gns3server/agent/gns3_copilot/skills/manager.py` - SkillsManager documentation and defaults
- `gns3server/agent/gns3_copilot/prompts/__init__.py` - Module documentation
- Documentation files in `docs/gns3-copilot/` directory