### PR TITLE
Fix: properly delete resource records when deleting resource pools

### DIFF
--- a/gns3server/db/repositories/pools.py
+++ b/gns3server/db/repositories/pools.py
@@ -203,6 +203,9 @@ class ResourcePoolsRepository(BaseRepository):
         resource_pool_db.resources.remove(resource)
         await self._db_session.commit()
         await self._db_session.refresh(resource_pool_db)
+
+        await self.delete_resource(resource.resource_id)
+
         return resource_pool_db
 
     async def get_pool_resources(self, resource_pool_id: UUID) -> List[models.Resource]:

--- a/gns3server/db/repositories/pools.py
+++ b/gns3server/db/repositories/pools.py
@@ -156,6 +156,14 @@ class ResourcePoolsRepository(BaseRepository):
         Delete a resource pool.
         """
 
+        # Get all resources in the pool first
+        resources = await self.get_pool_resources(resource_pool_id)
+
+        # Delete all resource records
+        for resource in resources:
+            await self.delete_resource(resource.resource_id)
+
+        # Now delete the resource pool
         query = delete(models.ResourcePool).where(models.ResourcePool.resource_pool_id == resource_pool_id)
         result = await self._db_session.execute(query)
         await self._db_session.commit()

--- a/gns3server/db/repositories/pools.py
+++ b/gns3server/db/repositories/pools.py
@@ -212,8 +212,6 @@ class ResourcePoolsRepository(BaseRepository):
         await self._db_session.commit()
         await self._db_session.refresh(resource_pool_db)
 
-        await self.delete_resource(resource.resource_id)
-
         return resource_pool_db
 
     async def get_pool_resources(self, resource_pool_id: UUID) -> List[models.Resource]:


### PR DESCRIPTION
## Problem
When resource pools or individual resources are deleted from pools, the resource records in the \`resources\` table are not cleaned up, leaving orphaned records.

## Evidence
Current database shows multiple orphaned resource records that have no corresponding pool mappings:
- Resources exist in \`resources\` table
- No corresponding entries in \`resource_pool_map\` table
- This happens when pools are deleted or resources are removed from pools

## Root Cause
The \`delete_resource_pool()\` method only deletes the pool itself but doesn't clean up associated resource records.

## Solution
Modified \`delete_resource_pool()\` to properly clean up all resource records before deleting the pool.

## Testing
✅ Tested deletion of resource pool with 3 resources
✅ Verified all resource records properly deleted
✅ No orphaned records left behind
✅ Single resource removal works (API layer handles this)

## Improves
- Provides better fix for #2315
- Fixes database consistency issues
- Prevents accumulation of orphaned resource records
