### PR TITLE
Fix project rename and duplicate issues (#2759)

### DIFF
--- a/gns3server/controller/project.py
+++ b/gns3server/controller/project.py
@@ -428,7 +428,21 @@ class Project:
 
     @name.setter
     def name(self, val):
+        old_filename = self._filename
         self._name = val
+        self._filename = val + ".gns3"
+
+        # Rename the .gns3 file on disk when the project name changes
+        if old_filename != self._filename:
+            old_path = os.path.join(self._path, old_filename)
+            new_path = os.path.join(self._path, self._filename)
+            if os.path.exists(old_path):
+                try:
+                    shutil.move(old_path, new_path)
+                    log.info(f"Project file renamed from '{old_filename}' to '{self._filename}'")
+                except OSError as e:
+                    log.warning(f"Could not rename project file from '{old_filename}' to '{self._filename}': {e}")
+                    self._filename = old_filename
 
     @property
     def id(self):
@@ -1404,7 +1418,11 @@ class Project:
         # copy dir
         await wait_run_in_executor(shutil.copytree, self.path, new_project_path.as_posix(), symlinks=True, ignore_dangling_symlinks=True)
         log.info("Project content copied from '{}' to '{}' in {}s".format(self.path, new_project_path, time.time() - t0))
-        topology = json.loads(new_project_path.joinpath('{}.gns3'.format(self.name)).read_bytes())
+
+        # Read the topology file using the actual filename (self._filename), not self.name
+        # This handles the case where a project has been renamed but we need to read the actual file
+        old_gns3_file = new_project_path.joinpath(self._filename)
+        topology = json.loads(old_gns3_file.read_bytes())
         project_name = name or topology["name"]
         # If the project name is already used we generate a new one
         project_name = self.controller.get_free_project_name(project_name)
@@ -1428,7 +1446,8 @@ class Project:
         if os.path.isdir(snapshots_dir):
             await update_snapshots(snapshots_dir, new_project_path, project_name, new_project_id)
 
-        os.remove(new_project_path.joinpath('{}.gns3'.format(self.name)))
+        # Remove the old .gns3 file (which has the original project name)
+        os.remove(old_gns3_file)
         project = await self.controller.load_project(dot_gns3_path, load=False)
         log.info("Project '{}': fast duplicated in {:.4f} seconds".format(project.name, time.time() - t0))
         return project


### PR DESCRIPTION
## Problem Description
Fixes #2759

When users rename a project and then perform "Save as" operation, they encounter an error:
```
Cannot duplicate project: [Errno 2] No such file or directory
```

## Root Cause Analysis

The issue occurs when a project has been renamed and then duplicated:

### Before Rename
- `self.name = "Lab1"`
- `self._filename = "Lab1.gns3"`
- Disk file: `Lab1.gns3` ✅

### After Rename (the problem)
- `self.name = "Lab1-bis"` ← Updated
- `self._filename = "Lab1.gns3"` ← **NOT updated**
- Disk file: `Lab1.gns3` ← **NOT renamed**

### During Duplicate
The `_fast_duplication` method uses `self.name` to construct the file path:
```python
topology = json.loads(new_project_path.joinpath('{}.gns3'.format(self.name)).read_bytes())
                                                     ↑
                                        Uses self.name = "Lab1-bis"
```

- Tries to read: `Lab1-bis.gns3` ❌
- Actual file: `Lab1.gns3`
- **File not found error!**

**Root cause**: When renaming a project, only the `self.name` is updated, but the .gns3 filename (`self._filename`) and the actual disk file are not updated. The duplicate operation then tries to read a file with the new name that doesn't exist.

## Changes Made

### 1. Modified `name.setter` - Rename .gns3 file when project is renamed

**File**: `gns3server/controller/project.py`

```python
@name.setter
def name(self, val):
    old_filename = self._filename
    self._name = val
    self._filename = val + ".gns3"
    
    # Rename the .gns3 file on disk when the project name changes
    if old_filename != self._filename:
        old_path = os.path.join(self._path, old_filename)
        new_path = os.path.join(self._path, self._filename)
        if os.path.exists(old_path):
            try:
                shutil.move(old_path, new_path)
                log.info(f"Project file renamed from '{old_filename}' to '{self._filename}'")
            except OSError as e:
                log.warning(f"Could not rename project file from '{old_filename}' to '{self._filename}': {e}")
                self._filename = old_filename
```

**What this does:**
- Updates `self._filename` to match the new project name
- Renames the .gns3 file on disk using `shutil.move()`
- Adds error handling and logging

### 2. Modified `_fast_duplication` - Use actual filename instead of project name

**File**: `gns3server/controller/project.py`

```python
# Read the topology file using the actual filename (self._filename)
old_gns3_file = new_project_path.joinpath(self._filename)
topology = json.loads(old_gns3_file.read_bytes())

# ... later in the code ...

# Remove the old .gns3 file
os.remove(old_gns3_file)
```

**What this does:**
- Uses `self._filename` (the actual filename) instead of `self.name`
- Handles the case where a project has been renamed
- Prevents "No such file or directory" errors

## Testing Performed

### Test 1: Empty project rename and duplicate
- ✅ Created empty project
- ✅ Renamed successfully (file renamed correctly)
- ✅ Duplicated successfully (no errors)

### Test 2: Project with multiple node types
- ✅ Created project with Dynamips, Docker, and other nodes
- ✅ Renamed successfully
- ✅ Duplicated successfully
- ✅ All nodes copied with correct new UUIDs
- ✅ Node configurations preserved

### Test 3: File verification
- ✅ Project name and ID correctly updated in duplicated .gns3 file
- ✅ All node IDs regenerated with new UUIDs
- ✅ Project files directory properly copied

## Impact

- **Minimal code changes**: Only 2 modifications, ~25 lines of code
- **Backward compatible**: Existing projects work without issues
- **No API changes**: No breaking changes to external interfaces
- **Performance**: No measurable performance impact

## Related Issues

- #2759 - Original issue report
- #2760 - Follow-up issue about unnecessary container recreation during rename