### PR TITLE
Fix unnecessary Docker container recreation when renaming a project

### DIFF
--- a/gns3server/controller/project.py
+++ b/gns3server/controller/project.py
@@ -197,9 +197,11 @@ class Project:
             self.emit_controller_notification("project.updated", self.asdict())
             self.dump()
 
-            # update on computes
-            for compute in list(self._project_created_on_compute):
-                await compute.put(f"/projects/{self._id}", {"variables": self.variables})
+            # Only notify computes if variables actually changed and have content
+            # None and empty list are semantically equivalent (no variables) and don't affect running nodes
+            if "variables" in kwargs and kwargs["variables"]:
+                for compute in list(self._project_created_on_compute):
+                    await compute.put(f"/projects/{self._id}", {"variables": self.variables})
 
     def reset(self):
         """


### PR DESCRIPTION
## Problem
When renaming a project that has running Docker containers, the containers are unnecessarily stopped, removed, and recreated, even though the project name change doesn't affect container configuration.

## Steps to Reproduce
1. Create a project with Docker nodes (e.g., Ostinato/Wireshark container)
2. Start the nodes so containers are running
3. Rename the project (e.g., "project1" → "project2")
4. Observe that Docker containers are stopped, removed, and recreated

## Expected Behavior
Renaming a project should only update the project metadata (name and .gns3 filename). It should not affect running containers since the project name doesn't influence container configuration.

## Root Cause
The issue is in the `Project.update()` method in `gns3server/controller/project.py`:
- When any project property changes (including just the name), the controller unconditionally sends a PUT request to all computes with `{"variables": self.variables}`
- Client sends complete project object including `variables: []` during rename
- Docker nodes' `update()` method destroys and recreates the container when notified

## Solution
Modified the `Project.update()` method to only notify compute nodes when the `variables` field has actual content:
- Treat `None` and `[]` as semantically equivalent (no variables)
- Only send update notification when `kwargs["variables"]` is truthy (has actual content)
- Empty variables don't affect running containers, so no need to update computes

## Testing
- Renaming a project with running Docker containers no longer triggers container recreation
- Container update still works correctly when variables are actually modified
- No impact on other node types (only Docker has update() method)

## Impact
- Project rename operations no longer trigger ~7 second container rebuilds
- Only actual variable changes trigger container recreation
- Fixes performance issue and prevents disruption of running workloads

## Related
Fixes #2760