### PR TITLE
Fix web-ui update script to handle custom GitHub URL changes

### DIFF
--- a/scripts/update-bundled-web-ui.sh
+++ b/scripts/update-bundled-web-ui.sh
@@ -94,6 +94,15 @@ if [ "$CUSTOM_REPO" = false ] ; then
         else
             git clone https://github.com/GNS3/gns3-web-ui.git "$REPO_DIR"
         fi
+    elif [[ -n "$GITHUB_URL" ]]; then
+        # Check if existing clone's remote matches the custom URL
+        EXISTING_REMOTE=$(cd "$REPO_DIR" && git config --get remote.origin.url)
+        if [[ "$EXISTING_REMOTE" != "$GITHUB_URL" ]]; then
+            echo "Remote URL mismatch: $EXISTING_REMOTE != $GITHUB_URL"
+            echo "Removing old clone and re-cloning..."
+            rm -rf "$REPO_DIR"
+            git clone "$GITHUB_URL" "$REPO_DIR"
+        fi
     fi
 
     cd "$REPO_DIR"


### PR DESCRIPTION
## Summary
- When using --url parameter with a different GitHub repository, the script now checks if the existing clone's remote matches the provided URL
- If they don't match, it removes the old clone and re-clones from the new URL
- This prevents errors when switching between different forks or branches of the gns3-web-ui repository

## Context
The update-bundled-web-ui.sh script caches the web-ui repository in /tmp/gns3-web-ui. When switching between different forks (e.g., from GNS3/gns3-web-ui to a personal fork), the cached clone retains the old remote URL. This causes git checkout to fail with "pathspec did not match any file(s) known to git" when trying to checkout a branch that exists in the new fork but not in the cached clone.