### PR TITLE
fix(templates): Database error detected when saving a template with a disk image change

### DIFF
--- a/gns3server/db/repositories/images.py
+++ b/gns3server/db/repositories/images.py
@@ -47,8 +47,16 @@ class ImagesRepository(BaseRepository):
                 where(models.Image.filename == image_name, models.Image.path.endswith(image_path))
         else:
             query = select(models.Image).where(models.Image.filename == image_name)
+        query = query.order_by(models.Image.image_id)
         result = await self._db_session.execute(query)
-        return result.scalars().first()
+        images = result.scalars().all()
+        if len(images) > 1:
+            log.warning(
+                f"Multiple DB entries found for image '{image_path}' "
+                f"({len(images)} rows). This indicates a data integrity issue. "
+                f"Using the entry with the lowest image_id ({images[0].image_id})."
+            )
+        return images[0] if images else None
 
     async def get_image_by_checksum(self, checksum: str, image_dir: str = None) -> Optional[models.Image]:
         """

--- a/gns3server/db/repositories/images.py
+++ b/gns3server/db/repositories/images.py
@@ -48,7 +48,7 @@ class ImagesRepository(BaseRepository):
         else:
             query = select(models.Image).where(models.Image.filename == image_name)
         result = await self._db_session.execute(query)
-        return result.scalars().one_or_none()
+        return result.scalars().first()
 
     async def get_image_by_checksum(self, checksum: str, image_dir: str = None) -> Optional[models.Image]:
         """

--- a/gns3server/db/repositories/images.py
+++ b/gns3server/db/repositories/images.py
@@ -47,16 +47,8 @@ class ImagesRepository(BaseRepository):
                 where(models.Image.filename == image_name, models.Image.path.endswith(image_path))
         else:
             query = select(models.Image).where(models.Image.filename == image_name)
-        query = query.order_by(models.Image.image_id)
         result = await self._db_session.execute(query)
-        images = result.scalars().all()
-        if len(images) > 1:
-            log.warning(
-                f"Multiple DB entries found for image '{image_path}' "
-                f"({len(images)} rows). This indicates a data integrity issue. "
-                f"Using the entry with the lowest image_id ({images[0].image_id})."
-            )
-        return images[0] if images else None
+        return result.scalars().one_or_none()
 
     async def get_image_by_checksum(self, checksum: str, image_dir: str = None) -> Optional[models.Image]:
         """

--- a/gns3server/db/repositories/templates.py
+++ b/gns3server/db/repositories/templates.py
@@ -124,7 +124,9 @@ class TemplatesRepository(BaseRepository):
         else:
             query = select(models.Image).where(models.Image.filename == image_name)
         result = await self._db_session.execute(query)
-        return result.scalars().one_or_none()
+        # Use first() instead of one_or_none() to handle cases where multiple
+        # DB rows share the same filename (e.g. image discovered in multiple paths)
+        return result.scalars().first()
 
     async def add_image_to_template(
             self,

--- a/gns3server/db/repositories/templates.py
+++ b/gns3server/db/repositories/templates.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import logging
 
 from uuid import UUID
 from typing import List, Union, Optional
@@ -28,6 +29,8 @@ from .base import BaseRepository
 
 import gns3server.db.models as models
 from gns3server import schemas
+
+log = logging.getLogger(__name__)
 
 TEMPLATE_TYPE_TO_MODEL = {
     "cloud": models.CloudTemplate,
@@ -123,10 +126,16 @@ class TemplatesRepository(BaseRepository):
                 where(models.Image.filename == image_name, models.Image.path.endswith(image_path))
         else:
             query = select(models.Image).where(models.Image.filename == image_name)
+        query = query.order_by(models.Image.image_id)
         result = await self._db_session.execute(query)
-        # Use first() instead of one_or_none() to handle cases where multiple
-        # DB rows share the same filename (e.g. image discovered in multiple paths)
-        return result.scalars().first()
+        images = result.scalars().all()
+        if len(images) > 1:
+            log.warning(
+                f"Multiple DB entries found for image '{image_path}' "
+                f"({len(images)} rows). This indicates a data integrity issue. "
+                f"Using the entry with the lowest image_id ({images[0].image_id})."
+            )
+        return images[0] if images else None
 
     async def add_image_to_template(
             self,

--- a/gns3server/services/templates.py
+++ b/gns3server/services/templates.py
@@ -267,9 +267,13 @@ class TemplatesService:
             raise ControllerNotFoundError(f"Template '{template_id}' not found")
         return template
 
-    async def _remove_image(self, template_id: UUID, image_path:str) -> None:
+    async def _remove_image(self, template_id: UUID, image_path: str) -> None:
 
+        if not image_path:
+            return
         image = await self._templates_repo.get_image(image_path)
+        if image is None:
+            return
         await self._templates_repo.remove_image_from_template(template_id, image)
 
     async def update_template(self, template_id: UUID, template_update: schemas.TemplateUpdate) -> dict:


### PR DESCRIPTION
### Problem

When editing a QEMU VM template in **Templates → Qemu VMs → (edit)**, changing the **HDA (Primary Master)** disk image by selecting a new value from the dropdown and clicking **Save** would silently revert to the old image on the next open. Attempting to save after the fix on the web-ui it exposed a secondary error in the server:

> **Database error detected, please check logs to find details**

#### Duplicate filenames in the image list — NG0955 + MultipleResultsFound
The GNS3 server discovers images on the filesystem and stores them in the database. If the same image filename exists under multiple paths (e.g. in both the global images folder and a per-project folder), multiple rows with the same filename can exist in the images table.

This caused two cascading failures:

Frontend (NG0955): The @for (image of filteredImages; track image.filename) directive uses image.filename as the tracking key. Duplicate filenames result in duplicate keys, throwing NG0955.

Server (MultipleResultsFound → "Database error detected"): When saving a template with a disk image change, the server calls _find_images() which calls _find_image(value), which calls TemplatesRepository.get_image(). That method used SQLAlchemy's .one_or_none() — when multiple rows share the same filename, SQLAlchemy raises MultipleResultsFound (a SQLAlchemyError). The global exception handler catches it and returns the generic "Database error detected" response.

The same .one_or_none() issue exists in ImagesRepository.get_image().

### Testing

1. Open Templates → Qemu VMs, duplicate an existing template.
2. Edit the duplicate — expand the HDD section.
3. Click the HDA (Primary Master) disk image field and select a different image from the dropdown.
4. Click Save — confirm "Changes saved" toast appears ( "Database error detected").
5. Navigate away and re-open the template — confirm the newly selected image is persisted.
6. Repeat for HDB, HDC, HDD fields.
7. Confirm no NG0955 errors appear in the browser console when the image list contains images discovered at multiple paths.

This pull request is related to https://github.com/GNS3/gns3-web-ui/pull/1720 which fixes the issue on the web-ui frontend