### PR TITLE
Fix web-wireshark docker build broken by xpra 6.5 release

### DIFF
--- a/gns3server/agent/web_wireshark/docker/Dockerfile
+++ b/gns3server/agent/web_wireshark/docker/Dockerfile
@@ -15,6 +15,7 @@ RUN sed -i 's|http://deb.debian.org/debian|http://mirrors.aliyun.com/debian|g' /
     && sed -i 's|http://security.debian.org/debian-security|http://mirrors.aliyun.com/debian-security|g' /etc/apt/sources.list.d/debian.sources
 
 # Add xpra official repository
+COPY pin-xpra /etc/apt/preferences.d/
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     wget \
@@ -24,11 +25,11 @@ RUN apt-get update && apt-get install -y \
     && apt-get update
 
 # Install xpra and dependencies
-# Lock xpra version for reproducible builds
+# Locking of xpra version is done in /etc/apt/preferences.d/pin-xpra
 RUN apt-get install -y \
     wireshark-common \
     wireshark \
-    xpra=6.4.3* \
+    xpra \
     xpra-x11 \
     xvfb \
     curl \

--- a/gns3server/agent/web_wireshark/docker/pin-xpra
+++ b/gns3server/agent/web_wireshark/docker/pin-xpra
@@ -1,0 +1,14 @@
+Explanation: Lock Xpra packages to v6.4
+Package: xpra*
+Pin: version 6.4*
+Pin-Priority: 1000
+
+Explanation: xpra-html5 uses different version scheme, lock it to v19
+Package: xpra-html5
+Pin: version 19*
+Pin-Priority: 1000
+
+Explanation: Block the installation of other xpra versions
+Package: xpra*
+Pin: version *
+Pin-Priority: -1


### PR DESCRIPTION
## Problem

Since 17 Jun the **Build Docker images** action fails because Xpra 6.5 was released. The Dockerfile pinned xpra with `xpra=6.4.3*`, which only constrains the `xpra` metapackage. Its sub-packages (`xpra-client`, `xpra-server`, `xpra-codecs`, …) were left unconstrained and default to 6.5, so apt can no longer satisfy the dependency graph:

```
xpra : Depends: xpra-client (= 6.4.4-r0-1) but it is not going to be installed
       Depends: xpra-client-gtk3 (= 6.4.4-r0-1) but it is not going to be installed
       ...
E: Unable to correct problems, you have held broken packages.
```

Tracked in **GNS3/gns3-registry#1044**.

## Fix

Replace the command-line version clamp with APT pinning via a new `/etc/apt/preferences.d/pin-xpra`:

- Pin every `xpra*` package to `6.4*` at priority `1000`.
- Pin `xpra-html5` to `19*` (it follows a separate version scheme; v19 was current alongside xpra 6.4).
- Block every other `xpra*` version with priority `-1`, so if the pinned version ever disappears from the repo apt **fails loudly** instead of silently upgrading to the latest.

The install line drops the `=6.4.3*` suffix and just installs `xpra` / `xpra-x11`.

This is the APT-pinning approach proposed by @b-ehlers in GNS3/gns3-registry#1044, which is cleaner than enumerating `=6.4*` against every sub-package on the command line.

## Files

- `gns3server/agent/web_wireshark/docker/pin-xpra` — new APT preferences file.
- `gns3server/agent/web_wireshark/docker/Dockerfile` — `COPY` the pin file, drop the `=6.4.3*` clamp.

Refs: GNS3/gns3-registry#1044