### PR TITLE
fix: thread token_version through MCP token minting and guard websocket auth failure

### DIFF
--- a/gns3server/api/routes/controller/dependencies/rbac.py
+++ b/gns3server/api/routes/controller/dependencies/rbac.py
@@ -52,6 +52,10 @@ def has_privilege_on_websocket(
             current_user: schemas.User = Depends(get_current_active_user_from_websocket),
             rbac_repo: RbacRepository = Depends(get_repository(RbacRepository))
     ):
+        # Authentication may have failed and closed the socket inside the auth
+        # dependency, returning None — bail out before touching the user object.
+        if current_user is None:
+            return None
         if not current_user.is_superadmin:
             path = re.sub(r"^/v[0-9]", "", websocket.url.path)  # remove the prefix (e.g. "/v3") from URL path
             log.debug(f"Checking user {current_user.username} has privilege {privilege_name} on '{path}'")

--- a/gns3server/api/routes/mcp/__init__.py
+++ b/gns3server/api/routes/mcp/__init__.py
@@ -194,6 +194,12 @@ _jwt_token_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
 _jwt_username_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "mcp_jwt_username", default=None
 )
+# token_version extracted during token validation — short-lived JWTs minted for
+# download/console URLs must carry the same version, or the revocation check
+# (token_data.token_version != user.token_version) rejects them as "revoked".
+_jwt_token_version_var: contextvars.ContextVar[int] = contextvars.ContextVar(
+    "mcp_jwt_token_version", default=0
+)
 
 
 # ── Token validation ──────────────────────────────────────────────────
@@ -208,8 +214,9 @@ async def _resolve_token(token: str) -> str | None:
     """
     # Try JWT first
     try:
-        username = auth_service.get_username_from_token(token)
-        _jwt_username_var.set(username)
+        token_data = auth_service.get_token_data(token)
+        _jwt_username_var.set(token_data.username)
+        _jwt_token_version_var.set(token_data.token_version)
         return token
     except Exception:
         pass
@@ -233,6 +240,7 @@ async def _resolve_token(token: str) -> str | None:
                                 user = await user_repo.get_user(db_key.user_id)
                                 if user:
                                     _jwt_username_var.set(user.username)
+                                    _jwt_token_version_var.set(user.token_version)
                                     fresh_token = auth_service.create_access_token(user.username, token_version=user.token_version)
                                     return fresh_token
             except Exception:
@@ -292,6 +300,7 @@ def _run_handler_sync(handler, params: dict[str, Any]) -> list[dict[str, Any]]:
         "server_url": _server_url(),
         "jwt_token": _jwt_token_var.get(),
         "jwt_username": _jwt_username_var.get(),
+        "jwt_token_version": _jwt_token_version_var.get(),
     }
     result = handler(params, ctx)
     return [{"type": "text", "text": json.dumps(result, ensure_ascii=False, default=str)}]

--- a/gns3server/api/routes/mcp/__init__.py
+++ b/gns3server/api/routes/mcp/__init__.py
@@ -233,7 +233,7 @@ async def _resolve_token(token: str) -> str | None:
                                 user = await user_repo.get_user(db_key.user_id)
                                 if user:
                                     _jwt_username_var.set(user.username)
-                                    fresh_token = auth_service.create_access_token(user.username)
+                                    fresh_token = auth_service.create_access_token(user.username, token_version=user.token_version)
                                     return fresh_token
             except Exception:
                 pass

--- a/gns3server/api/routes/mcp/__init__.py
+++ b/gns3server/api/routes/mcp/__init__.py
@@ -571,16 +571,18 @@ async def node_console(
     Complete workflow:
       1. Call this tool with project_id and node_id to get the WebSocket URL
       2. Connect to the returned URL using websocat in text mode (-t):
-         > websocat -t "ws://<your-gns3-server-host>:3080/v3/projects/{project_id}/nodes/{node_id}/console/ws?token={jwt_token}"
+         > websocat -t --no-close "ws://<your-gns3-server-host>:3080/v3/projects/{project_id}/nodes/{node_id}/console/ws?token={jwt_token}"
       3. Send device commands with \\r\\n line endings via heredoc:
-         > websocat -t "ws://..." <<< $'\\r\\nenable\\r\\nshow version\\r\\nexit\\r\\n'
+         > websocat -t --no-close "ws://..." <<< $'\\r\\nenable\\r\\nshow version\\r\\nexit\\r\\n'
       4. Receive response: websocat receives and displays device output
          Use 'timeout' to avoid connection hanging:
-         > timeout 10 websocat -t "ws://..." <<< $'commands\\r\\n'
+         > timeout 10 websocat -t --no-close "ws://..." <<< $'commands\\r\\n'
 
     Key points:
       - Use \\r\\n (not \\n) to match console protocol line endings
       - Use $'...' format for escape sequences in bash
+      - --no-close keeps the WebSocket open after stdin (heredoc) hits EOF, so
+        device output is not cut off before it arrives
       - Set a timeout to prevent hanging connections
     """
     return await asyncio.to_thread(_run_handler_sync, get_node_console_info_handler, {

--- a/gns3server/api/routes/mcp/links.py
+++ b/gns3server/api/routes/mcp/links.py
@@ -336,7 +336,7 @@ def download_capture_file_handler(params: dict[str, Any], gns3_ctx: dict[str, An
     if not project_id:
         return {"error": "project_id is required"}
     username = gns3_ctx.get("jwt_username")
-    download_token = auth_service.create_access_token(username, expires_in=10) if username else None
+    download_token = auth_service.create_access_token(username, token_version=gns3_ctx.get("jwt_token_version", 0), expires_in=10) if username else None
 
     link_ids = params.get("link_ids")
     if link_ids:

--- a/gns3server/api/routes/mcp/nodes.py
+++ b/gns3server/api/routes/mcp/nodes.py
@@ -328,7 +328,7 @@ def get_node_console_info_handler(params: dict[str, Any], gns3_ctx: dict[str, An
         "node_name": node.get("name"),
         "console_type": console_type,
         "ws_url": ws_url,
-        "command": f"websocat {ws_url}",
+        "command": f"websocat -t --no-close {ws_url}",
     }
     if console_type in ("vnc",):
         result["vnc_url"] = f"/v3/projects/{project_id}/nodes/{node_id}/console/vnc?token={gns3_ctx['jwt_token']}"

--- a/gns3server/api/routes/mcp/nodes.py
+++ b/gns3server/api/routes/mcp/nodes.py
@@ -316,7 +316,7 @@ def get_node_console_info_handler(params: dict[str, Any], gns3_ctx: dict[str, An
     console_type = node.get("console_type", "unknown")
     # Short-lived JWT for the WebSocket URL (10 min)
     username = gns3_ctx.get("jwt_username")
-    ws_token = auth_service.create_access_token(username, expires_in=10) if username else None
+    ws_token = auth_service.create_access_token(username, token_version=gns3_ctx.get("jwt_token_version", 0), expires_in=10) if username else None
     raw_url = f"{gns3_ctx['server_url']}/v3/projects/{project_id}/nodes/{node_id}/console/ws"
     if ws_token:
         raw_url += f"?token={ws_token}"

--- a/gns3server/api/routes/mcp/symbols.py
+++ b/gns3server/api/routes/mcp/symbols.py
@@ -54,7 +54,7 @@ def get_symbol_handler(params: dict[str, Any], gns3_ctx: dict[str, Any]) -> dict
         return {"error": "symbol_id is required"}
     download_url = f"{gns3_ctx['server_url']}/v3/symbols/{symbol_id}/raw"
     username = gns3_ctx.get("jwt_username")
-    download_token = auth_service.create_access_token(username, expires_in=10) if username else None
+    download_token = auth_service.create_access_token(username, token_version=gns3_ctx.get("jwt_token_version", 0), expires_in=10) if username else None
     result = {
         "symbol_id": symbol_id,
         "download_url": download_url,


### PR DESCRIPTION
## Summary

Four small, related fixes to the MCP console/download token path and websocket auth failure handling, found while debugging why the controller rejected freshly minted console tokens as `"Token has been revoked"`.

## Background

Token revocation is a strict version check: a token is rejected when its embedded `ver` (`token_version`) differs from the user's current `token_version` (incremented on logout). `AuthService.create_access_token()` defaults `token_version` to `0`, so any minting site that omits it produces tokens that are **born "revoked"** for any user who has logged out at least once.

## Changes

- **fix(mcp): pass `token_version` when minting a temp JWT from an API key** — `_resolve_token` minted the short-lived JWT with the default `ver=0`, so API-key users past their first logout were rejected on every MCP call.
- **fix(mcp): thread `token_version` into console/download token minting** — the short-lived JWTs minted for the console WebSocket URL (`nodes`) and the download URLs (`symbols`, `links`) also omitted `token_version`. Now resolved once in `_resolve_token` (JWT branch decodes it, API-key branch reads `user.token_version`), carried through `gns3_ctx`, and passed at every minting call.
- **fix(rbac): guard `None` `current_user` on websocket auth failure** — `get_current_active_user_from_websocket` returns `None` after closing the socket on an auth failure; `has_privilege_on_websocket` dereferenced `current_user.is_superadmin` without a `None` check, so any websocket auth failure surfaced as an `AttributeError` traceback instead of a clean close. (This is how the token bug above first surfaced.)
- **docs(mcp): note `--no-close` for `node_console` websocat usage** — a heredoc (`<<<`) closes stdin immediately, so `websocat` dropped the connection before the device reply arrived; added `--no-close` to the usage examples and the returned `command` field.

## Testing

- `tests/api/routes/mcp/` — 39 passed
- `tests/api/routes/controller/test_users.py` (token / version / revoke / auth) — 30 passed