### PR TITLE
docs: add structured bug-report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,40 @@
+name: Bug report
+description: Report a bug so we can fix it.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this? Numbered steps if possible.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen instead?
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      description: Which version or commit hash are you on?
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, runtime version, anything else that might be relevant.
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any relevant log output. This is automatically rendered as code.
+      render: shell


### PR DESCRIPTION
Adds `bug_report.yml` as a GitHub issue-form. Compared to plain markdown templates, forms enforce required fields (like reproduction steps) which cuts down on low-signal bug reports.

The `render: shell` on the logs field auto-renders pasted output as a code block, which is a nice touch.