### PR TITLE
fix: correct always-true state check in DockerVM.stop()

### DIFF
--- a/gns3server/compute/docker/docker_vm.py
+++ b/gns3server/compute/docker/docker_vm.py
@@ -869,7 +869,7 @@ class DockerVM(BaseNode):
                 await self._fix_permissions()
 
             state = await self._get_container_state()
-            if state != "stopped" or state != "exited":
+            if state != "stopped" and state != "exited":
                 # t=5 number of seconds to wait before killing the container
                 try:
                     await self.manager.query("POST", "containers/{}/stop".format(self._cid), params={"t": 5})

--- a/tests/compute/docker/test_docker_vm.py
+++ b/tests/compute/docker/test_docker_vm.py
@@ -1503,3 +1503,19 @@ async def test_read_console_output_with_binary_mode(vm):
     with asyncio_patch('gns3server.compute.docker.docker_vm.DockerVM.stop'):
         await vm._read_console_output(input_stream, output_stream)
         output_stream.feed_data.assert_called_once_with(b"test")
+
+
+async def test_stop_exited_container_no_stop_query(vm):
+
+    vm._ubridge_hypervisor = None
+    vm._fix_permissions = MagicMock()
+
+    with asyncio_patch("gns3server.compute.docker.DockerVM._get_container_state", return_value="exited"):
+        with asyncio_patch("gns3server.compute.docker.Docker.query") as mock_query:
+            vm._permissions_fixed = False
+            await vm.stop()
+            assert not any(
+                call.args[:2] == ("POST", "containers/e90e34656842/stop")
+                for call in mock_query.mock_calls
+            )
+    assert vm.status == "stopped"


### PR DESCRIPTION
Closes #2820

`state != "stopped" or state != "exited"` is always true, so the state check in `DockerVM.stop()` never gated anything and a stop request was sent even for an already-exited container. `_get_container_state()` never returns `"stopped"`, and the intended negation of the `_fix_permissions()` condition needs `and` (De Morgan), so this is a one-token fix.

Added a regression test asserting no stop query is issued when the container has already exited; it fails without the fix and passes with it.
