### PR TITLE
Do not start nodes when deleting a project

### DIFF
--- a/gns3server/controller/project.py
+++ b/gns3server/controller/project.py
@@ -917,7 +917,7 @@ class Project:
 
         if self._status != "opened":
             try:
-                await self.open()
+                await self.open(auto_start=False)
             except aiohttp.web.HTTPConflict as e:
                 # ignore missing images or other conflicts when deleting a project
                 log.warning(f"Conflict while deleting project: {e}")
@@ -998,9 +998,12 @@ class Project:
         return os.path.join(self.path, self._filename)
 
     @locking
-    async def open(self):
+    async def open(self, auto_start=True):
         """
         Load topology elements
+
+        :param auto_start: whether the nodes may be started when the project
+            has auto start enabled
         """
 
         if self._closing:
@@ -1114,7 +1117,7 @@ class Project:
         self._loading = False
         self.emit_controller_notification("project.opened", self.__json__())
         # Should we start the nodes when project is open
-        if self._auto_start:
+        if self._auto_start and auto_start:
             # Start all in the background without waiting for completion
             # we ignore errors because we want to let the user open
             # their project and fix it

--- a/tests/controller/test_project.py
+++ b/tests/controller/test_project.py
@@ -655,6 +655,19 @@ async def test_delete(project):
     assert not os.path.exists(project.path)
 
 
+async def test_delete_does_not_start_nodes(project):
+    """
+    Deleting a project must not start its nodes, even when auto_start is enabled.
+    """
+
+    project.auto_start = True
+    project.dump()
+    await project.close()
+    project.start_all = AsyncioMagicMock()
+    await project.delete()
+    assert not project.start_all.called
+
+
 async def test_dump(projects_dir):
 
     directory = projects_dir


### PR DESCRIPTION
Fixes #2784

`Project.delete()` calls `open()` to rebuild the data structures needed for cleanup, but `open()` schedules `start_all()` when `auto_start` is enabled — so deleting an auto-start project actually launches every node process, allocating ports and consuming resources, only for the following `close()` to kill them.

`open()` now takes an `auto_start` argument (default `True`, so normal opens are unchanged) and `delete()` passes `auto_start=False`. Added `test_delete_does_not_start_nodes`, which fails on master (`start_all` is called) and passes with the fix.
