### PR TITLE
fix(qemu): remove trailing space from RNG object argument

### DIFF
--- a/gns3server/compute/qemu/qemu_vm.py
+++ b/gns3server/compute/qemu/qemu_vm.py
@@ -2107,7 +2107,7 @@ class QemuVM(BaseNode):
             options.extend(["-drive", "if=pflash,format=raw,file={}".format(ovmf_vars_node_path)])
 
             # edk2 firmware requires a Random Number Generator (RNG) device in order to turn network adapters on
-            options.extend(["-object", "rng-random,filename=/dev/urandom,id=rng0 "])
+            options.extend(["-object", "rng-random,filename=/dev/urandom,id=rng0"])
             options.extend(["-device", "virtio-rng-pci,rng=rng0"])
         return options
 


### PR DESCRIPTION
Fixes: #2835

Removes an unintended trailing space from the QEMU RNG object argument. The extra whitespace caused UEFI-enabled QEMU VMs to fail during startup in GNS3 Server 2.2.60.

Before the fix:
```
qemu-system-aarch64: -object rng-random,filename=/dev/urandom,id=rng0 : Parameter 'id' expects an identifier
Identifiers consist of letters, digits, '-', '.', '_', starting with a letter.
```

After the fix the error is gone.