### PR TITLE
fix: lowercase GHCR image name in docker-build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -28,6 +28,13 @@ jobs:
           echo "stable=false" >> $GITHUB_OUTPUT
         fi
 
+    - name: Set lowercase image name vars
+      if: steps.ver.outputs.stable == 'true'
+      id: names
+      run: |
+        echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+        echo "repo=$(echo '${{ github.event.repository.name }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
     - name: Set up Docker Buildx
       if: steps.ver.outputs.stable == 'true'
       uses: docker/setup-buildx-action@v3
@@ -57,5 +64,5 @@ jobs:
         tags: |
           ${{ env.DOCKERHUB_ORG }}/${{ github.event.repository.name }}:${{ steps.ver.outputs.tag }}
           ${{ env.DOCKERHUB_ORG }}/${{ github.event.repository.name }}:latest
-          ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ steps.ver.outputs.tag }}
-          ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:latest
+          ghcr.io/${{ steps.names.outputs.owner }}/${{ steps.names.outputs.repo }}:${{ steps.ver.outputs.tag }}
+          ghcr.io/${{ steps.names.outputs.owner }}/${{ steps.names.outputs.repo }}:latest


### PR DESCRIPTION
GHCR requires image names to be lowercase. `github.repository_owner` returns the owner's original casing (e.g. `GNS3`), which causes the push to `ghcr.io/GNS3/gns3-server` to fail.

Adds a step to lowercase both the owner and repo name before constructing the GHCR image tag.