### PR TITLE
Fix IOU serial-link captures always written as Ethernet (DLT_EN10MB)

### DIFF
--- a/gns3server/api/routes/compute/iou_nodes.py
+++ b/gns3server/api/routes/compute/iou_nodes.py
@@ -288,7 +288,7 @@ async def start_iou_node_capture(
     """
 
     pcap_file_path = os.path.join(node.project.capture_working_directory(), node_capture_data.capture_file_name)
-    await node.start_capture(adapter_number, port_number, pcap_file_path)
+    await node.start_capture(adapter_number, port_number, pcap_file_path, node_capture_data.data_link_type)
     return {"pcap_file_path": str(pcap_file_path)}
 
 


### PR DESCRIPTION
## Problem

Capturing on an **IOU serial link** always produced an Ethernet pcap (`DLT_EN10MB`, linktype 1), regardless of the encapsulation (Cisco HDLC / PPP / Frame Relay) chosen in the capture dialog — so Wireshark mis-decodes the WAN frames. Dynamips serial capture is correct; only IOU is affected.

## Root cause

The IOU compute route `POST /nodes/{id}/adapters/{a}/ports/{p}/capture/start` receives `data_link_type` in the `NodeCapture` body but **dropped it** when calling the node:

```python
await node.start_capture(adapter_number, port_number, pcap_file_path)   # data_link_type missing
```

`IOUVM.start_capture` defaults its 4th parameter to `DLT_EN10MB`, so `iol_bridge start_capture` was always sent `EN10MB`. Dynamips, cloud and the L2 switches already forward `node_capture_data.data_link_type`; IOU was the only serial-capable node that omitted it.

(The ethernet-only nodes — qemu/docker/vpcs/virtualbox/vmware — also omit it, but they have no serial ports, so `data_link_type` is always `EN10MB` there and the omission has no effect.)

## Fix

One argument:

```python
await node.start_capture(adapter_number, port_number, pcap_file_path, node_capture_data.data_link_type)
```

`IOUVM.start_capture` already accepts and forwards `data_link_type` to `iol_bridge start_capture`; only the route was missing it.

## Verification

After the fix, an IOU serial capture with Cisco HDLC / PPP / Frame Relay selected yields the correct pcap linktype (`C_HDLC` = 104 / `PPP_SERIAL` = 50 / `FRELAY` = 107) instead of Ethernet (1).


## Note

This one-line fix is also contained in #2844 (the marker PR, branched later) since the marker serial-link work depends on correct IOU serial capture. If #2844 lands first this PR is redundant; either can merge independently.
