### PR TITLE
fix: SIGKILL docker container on stop instead of 5s grace period

### DIFF
--- a/gns3server/compute/docker/docker_vm.py
+++ b/gns3server/compute/docker/docker_vm.py
@@ -1049,11 +1049,14 @@ class DockerVM(BaseNode):
 
             state = await self._get_container_state()
             if state != "stopped" and state != "exited":
-                # t=5 number of seconds to wait before killing the container
+                # SIGKILL immediately. GNS3 has already persisted container state
+                # (permissions via _fix_permissions, /gns3volumes) before this
+                # point, and the business process (often an interactive shell)
+                # ignores SIGTERM — so a stop grace period buys nothing but latency.
                 try:
-                    await self.manager.query("POST", f"containers/{self._cid}/stop", params={"t": 5})
+                    await self.manager.query("POST", f"containers/{self._cid}/kill")
                     log.info(f"Docker container '{self._name}' [{self._image}] stopped")
-                except DockerHttp304Error:
+                except DockerHttp409Error:
                     # Container is already stopped
                     pass
         # Ignore runtime error because when closing the server

--- a/tests/compute/docker/test_docker_vm.py
+++ b/tests/compute/docker/test_docker_vm.py
@@ -1209,7 +1209,7 @@ async def test_stop(vm):
         with asyncio_patch("gns3server.compute.docker.Docker.query") as mock_query:
             vm._permissions_fixed = False
             await vm.stop()
-            mock_query.assert_called_with("POST", "containers/e90e34656842/stop", params={"t": 5})
+            mock_query.assert_called_with("POST", "containers/e90e34656842/kill")
     assert mock.stop.called
     assert vm._ubridge_hypervisor is None
     assert vm._fix_permissions.called
@@ -1222,7 +1222,7 @@ async def test_stop_paused_container(vm):
         with asyncio_patch("gns3server.compute.docker.DockerVM.unpause") as mock_unpause:
             with asyncio_patch("gns3server.compute.docker.Docker.query") as mock_query:
                 await vm.stop()
-                mock_query.assert_called_with("POST", "containers/e90e34656842/stop", params={"t": 5})
+                mock_query.assert_called_with("POST", "containers/e90e34656842/kill")
                 assert mock_unpause.called
 
 
@@ -1894,7 +1894,7 @@ async def test_stop_exited_container_no_stop_query(vm):
             vm._permissions_fixed = False
             await vm.stop()
             assert not any(
-                call.args[:2] == ("POST", "containers/e90e34656842/stop")
+                call.args[:2] == ("POST", "containers/e90e34656842/kill")
                 for call in mock_query.mock_calls
             )
     assert vm.status == "stopped"


### PR DESCRIPTION
## Problem
Docker node `stop()` took ~5s every time. The `stop` API grace period (`params={"t": 5}`, unchanged since 2015) was always exhausted before SIGKILL.

Visible in logs:
```
21:15:18  fix ownership, state = running
21:15:23  stopped          ← 5s gap
```

## Why the grace period was pure waste
- The business process (often an interactive shell, e.g. `bash`) ignores SIGTERM.
- GNS3 doesn't depend on graceful container shutdown: `_fix_permissions` and `/gns3volumes` already persist container state **before** `stop()` issues the docker stop call.

## Why `t=5`
Traced to commit `33edbefa3` (2015-10-14) "Docker cleanup and improvements" — introduced with no recorded rationale. It isn't Docker's default (10s) and was never revisited in 11 years.

## Fix
Use `POST /containers/{id}/kill` (SIGKILL, zero delay) instead of `stop?t=5`. SIGKILL can't be caught or ignored, so this is reliable regardless of PID 1 / business process. Catch `409` (container already stopped) replaces the previous `304` handling for the race where the container exits between the state check and the call.

## Verification
- `pytest tests/compute/docker/` — 86 passed.
- End-to-end: stopping 3 ubuntu containers went from ~5s to <1s (fix-ownership and `stopped` in the same second).