### PR TITLE
fix: suppress redundant console port setter log during Docker node create

### DIFF
--- a/gns3server/api/routes/compute/docker_nodes.py
+++ b/gns3server/api/routes/compute/docker_nodes.py
@@ -81,6 +81,15 @@ async def create_docker_node(project_id: UUID, node_data: schemas.DockerCreate) 
         memory=node_data.get("memory", 0),
         cpus=node_data.get("cpus", 0),
     )
+    # Pop keys already consumed by create_node above so the setattr
+    # fallback loop below only applies truly extra keys and does not
+    # re-trigger console/aux port setter logging.
+    for key in (
+        "console", "console_type", "console_resolution", "console_http_port",
+        "console_http_path", "aux", "aux_type", "start_command", "environment",
+        "adapters", "mac_address", "extra_hosts", "extra_volumes", "memory", "cpus",
+    ):
+        node_data.pop(key, None)
     for name, value in node_data.items():
         if name != "node_id":
             if hasattr(container, name) and getattr(container, name) != value:


### PR DESCRIPTION
## Problem

When opening a large project (e.g. 500 Docker containers), the server log is flooded with:

```
INFO gns3server.compute.base_node:775 Docker: 'FRRDockerLite-87' [...]: console port set to 5086
```

This does **not** appear with smaller projects (e.g. 100 containers).

## Root cause

`create_docker_node()` passes `console`, `aux`, `console_type`, etc. to `create_node()` via `node_data.get(...)`, so those keys remain in `node_data`. The subsequent setattr fallback loop then re-applies them:

```python
for name, value in node_data.items():
    if name != "node_id":
        if hasattr(container, name) and getattr(container, name) != value:
            setattr(container, name, value)
```

In `base_node.__init__`, `reserve_tcp_port()` can silently substitute a different port when the requested one is already in `_used_tcp_ports` or occupied at the OS level (TIME_WAIT etc.). Under high-density deployment (500 nodes) this happens often enough that `self._console` ends up differing from the original `node_data["console"]`. The fallback loop then detects the mismatch and re-invokes the `console` setter — firing the INFO log and performing a wasted release→reserve round-trip.

The final port is still correct (it reserves the original port back), so this is purely log noise + redundant work, not a functional bug.

## Fix

Pop the 15 keys already consumed by `create_node()` before the setattr fallback loop, so the loop only handles truly extra keys and never re-triggers the console/aux port setters.

```python
for key in (
    "console", "console_type", "console_resolution", "console_http_port",
    "console_http_path", "aux", "aux_type", "start_command", "environment",
    "adapters", "mac_address", "extra_hosts", "extra_volumes", "memory", "cpus",
):
    node_data.pop(key, None)
```

Diff: `docker_nodes.py` +9 lines, no behavior change for normal creation.

## Tests

- `tests/api/routes/compute/test_docker_nodes.py` — 26 passed
- `tests/compute/test_base_node.py` — 29 passed