### PR TITLE
docs: document the BusyBox ifup CIDR trap in the docker init path

### DIFF
--- a/gns3server/compute/docker/docker_vm.py
+++ b/gns3server/compute/docker/docker_vm.py
@@ -511,6 +511,11 @@ class DockerVM(BaseNode):
                 f.write("""#
 # This is a sample network config, please uncomment lines to configure the network
 #
+# NOTE: at boot /gns3/init.sh applies this file with BusyBox ifup ("ifup -a -f").
+# BusyBox ifupdown only brings up "auto" stanzas and requires separate
+# "address <ip>" and "netmask <mask>" lines: CIDR notation such as
+# "address 10.0.0.1/24" is rejected and the interface stays unconfigured.
+#
 
 # Uncomment this line to load custom interface files
 # source /etc/network/interfaces.d/*

--- a/gns3server/compute/docker/resources/init.sh
+++ b/gns3server/compute/docker/resources/init.sh
@@ -87,6 +87,11 @@ sed -n 's/^ *\(eth[0-9]*\):.*/\1/p' < /proc/net/dev | while read dev; do
 done
 
 # configure network interfaces
+# NOTE: unless the image ships its own ifupdown in /sbin this is BusyBox ifup,
+# which only brings up 'auto' stanzas and does NOT understand CIDR notation:
+# 'address <ip>' and 'netmask <mask>' must be separate lines, otherwise the
+# stanza fails with "don't have all variables for <iface>/inet" and the
+# interface comes up unconfigured.
 ifup -a -f
 
 # continue normal docker startup


### PR DESCRIPTION
## Summary

Comment-only change (no behaviour change) documenting a support trap in the Docker node init path:

- `gns3server/compute/docker/resources/init.sh` — note above `ifup -a -f` that this is BusyBox ifup unless the image ships its own ifupdown, that only `auto` stanzas are processed, and that CIDR notation in the address line (`address 10.0.0.1/24`) is rejected with "don't have all variables for <iface>/inet", leaving the interface unconfigured after a restart.
- `gns3server/compute/docker/docker_vm.py` `_create_network_config()` — same warning inlined into the generated `/etc/network/interfaces` sample, i.e. right where users (and LLM-driven tooling) write addressing.

## Context

Root-caused from a real topology: addresses written with CIDR syntax silently failed at boot and the container came up unconfigured, which then got misdiagnosed as "the init path never applies the file" (PID 1 cmdline only shows the post-`exec` start command, and `which ifup` is empty in an interactive shell even though BusyBox ifup runs at boot). The generated sample file showing the correct separate `address`/`netmask` form aims to prevent both the original syntax mistake and the misdiagnosis.